### PR TITLE
[Bug/#26] merge시 트리거되는 중복 CI/CD 워크플로우 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop') || github.event_name == 'push'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🔎 Description
> Develop 브랜치로의 병합 시 두 개의 GitHub Actions 워크플로우가 중복해서 실행되는 문제를 해결했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/26](https://github.com/Central-MakeUs/Easybud-Server/issues/26)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Code Refactor
- [x] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [x] 💚 CI Fix
