### PR TITLE
[Bug/#29] Rebase Merge시 CI/CD 워크플로우 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
+    if: github.event.pull_request.base.ref == 'develop'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🔎 Description
> Rebase Merge시 워크플로우가 건너뛰어지는 문제를 해결하기 위하여 Github Actions 워크플로우를 수정했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/29](https://github.com/Central-MakeUs/Easybud-Server/issues/29)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Code Refactor
- [x] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [x] 💚 CI Fix
