### PR TITLE
[Bug/#26] workflows push trigger 제거

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,19 +1,14 @@
 name: Easybud dev CI/CD
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     types: [ closed ]
-    branches:
-      - develop
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop')
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🔎 Description
> pull request merge시에만 작동하도록 push 관련 트리거를 삭제했습니다.

## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/26](https://github.com/Central-MakeUs/Easybud-Server/issues/26)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [x] 💚 CI Fix
