### PR TITLE
[Feat/#40] 특정 회원 거래 조회를 위한 거래 API 수정

### DIFF
--- a/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
+++ b/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.friends.easybud.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,8 +16,11 @@ public class SwaggerConfig {
                 .version("v0.0.1")
                 .description("Easybud의 API 명세서입니다.");
 
+        Server server = new Server().url("/");
+
         return new OpenAPI()
                 .components(new Components())
-                .info(info);
+                .info(info)
+                .addServersItem(server);
     }
 }

--- a/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
-    List<Transaction> findByDateBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<Transaction> findByMemberIdAndDateBetween(Long memberId, LocalDateTime startDateTime,
+                                                   LocalDateTime endDateTime);
 
-    List<Transaction> findTop3ByOrderByDateDesc();
+    List<Transaction> findTop3ByMemberIdOrderByDateDesc(Long memberId);
 
 }

--- a/src/main/java/com/friends/easybud/transaction/service/TransactionQueryServiceImpl.java
+++ b/src/main/java/com/friends/easybud/transaction/service/TransactionQueryServiceImpl.java
@@ -25,12 +25,14 @@ public class TransactionQueryServiceImpl implements TransactionQueryService {
 
     @Override
     public List<Transaction> getTransactionsBetweenDates(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return transactionRepository.findByDateBetween(startDateTime, endDateTime);
+        Long memberId = 1L;
+        return transactionRepository.findByMemberIdAndDateBetween(memberId, startDateTime, endDateTime);
     }
 
     @Override
     public List<Transaction> getRecentTransactions() {
-        return transactionRepository.findTop3ByOrderByDateDesc();
+        Long memberId = 1L;
+        return transactionRepository.findTop3ByMemberIdOrderByDateDesc(memberId);
     }
 
 }


### PR DESCRIPTION
## 🔎 Description
> 거래 조회 API를 특정 회원의 거래만 조회하도록 수정하였습니다.
Swagger 테스트 시 http → https로 요청하기 위해 Server base url을 "/"로 설정했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/40](https://github.com/Central-MakeUs/Easybud-Server/issues/40)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
