### PR TITLE
[Feat/#43] Slack API 활용하여 서버 에러 모니터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     // p5spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
+    // slack
+    implementation 'com.slack.api:slack-api-client:1.28.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/friends/easybud/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/friends/easybud/global/exception/ExceptionAdvice.java
@@ -4,11 +4,14 @@ package com.friends.easybud.global.exception;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.global.response.code.Reason;
+import com.friends.easybud.global.slack.SlackService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -21,8 +24,12 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+@Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    private final SlackService slackService;
 
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
@@ -54,7 +61,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
-
+        slackService.sendSlackMessageProductError(e);
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
                 ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
     }
@@ -124,4 +131,5 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 request
         );
     }
+
 }

--- a/src/main/java/com/friends/easybud/global/response/ResponseDto.java
+++ b/src/main/java/com/friends/easybud/global/response/ResponseDto.java
@@ -21,11 +21,12 @@ public class ResponseDto<T> {
     }
 
     public static <T> ResponseDto<T> of(BaseCode code, T result) {
-        return new ResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+        return new ResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(),
+                result);
     }
 
-    public static <T> ResponseDto<T> onFailure(Integer code, String message, T data){
-        return new ResponseDto<>(true, code, message, data);
+    public static <T> ResponseDto<T> onFailure(Integer code, String message, T data) {
+        return new ResponseDto<>(false, code, message, data);
     }
 
 }

--- a/src/main/java/com/friends/easybud/global/slack/SlackService.java
+++ b/src/main/java/com/friends/easybud/global/slack/SlackService.java
@@ -16,9 +16,9 @@ public class SlackService {
 
     @Value(value = "${spring.profiles.active}")
     String profile;
-    @Value(value = "${slack.token}")
+    @Value(value = "${slack.token:}")
     String token;
-    @Value(value = "${slack.channel.monitor}")
+    @Value(value = "${slack.channel.monitor:}")
     String channelProductError;
 
     private static final String LOCAL = "local";

--- a/src/main/java/com/friends/easybud/global/slack/SlackService.java
+++ b/src/main/java/com/friends/easybud/global/slack/SlackService.java
@@ -1,4 +1,4 @@
-package com.friends.easybud.slack;
+package com.friends.easybud.global.slack;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;

--- a/src/main/java/com/friends/easybud/global/slack/SlackService.java
+++ b/src/main/java/com/friends/easybud/global/slack/SlackService.java
@@ -1,0 +1,43 @@
+package com.friends.easybud.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.block.LayoutBlock;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class SlackService {
+
+    @Value(value = "${spring.profiles.active}")
+    String profile;
+    @Value(value = "${slack.token}")
+    String token;
+    @Value(value = "${slack.channel.monitor}")
+    String channelProductError;
+
+    private static final String LOCAL = "local";
+    private static final String PROD_ERROR_MESSAGE_TITLE = "🤯 *500 에러 발생*";
+    private static final String ATTACHMENTS_ERROR_COLOR = "#eb4034";
+
+    public void sendSlackMessageProductError(Exception exception) {
+        if (!profile.equals(LOCAL)) {
+            try {
+                List<LayoutBlock> layoutBlocks = SlackServiceUtils.createProdErrorMessage(exception);
+                List<Attachment> attachments = SlackServiceUtils.createAttachments(ATTACHMENTS_ERROR_COLOR,
+                        layoutBlocks);
+                Slack.getInstance().methods(token).chatPostMessage(request ->
+                        request.channel(channelProductError)
+                                .attachments(attachments)
+                                .text(PROD_ERROR_MESSAGE_TITLE));
+            } catch (SlackApiException | IOException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/friends/easybud/global/slack/SlackServiceUtils.java
+++ b/src/main/java/com/friends/easybud/global/slack/SlackServiceUtils.java
@@ -1,4 +1,4 @@
-package com.friends.easybud.slack;
+package com.friends.easybud.global.slack;
 
 import static com.slack.api.model.block.Blocks.divider;
 import static com.slack.api.model.block.Blocks.section;

--- a/src/main/java/com/friends/easybud/global/slack/SlackServiceUtils.java
+++ b/src/main/java/com/friends/easybud/global/slack/SlackServiceUtils.java
@@ -1,0 +1,54 @@
+package com.friends.easybud.slack;
+
+import static com.slack.api.model.block.Blocks.divider;
+import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+
+import com.slack.api.model.Attachment;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.TextObject;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SlackServiceUtils {
+
+    private static final String ERROR_MESSAGE = "*Error Message:*\n";
+    private static final String ERROR_STACK = "*Error Stack:*\n";
+    private static final String FILTER_STRING = "blossom";
+
+    public static List<Attachment> createAttachments(String color, List<LayoutBlock> data) {
+        List<Attachment> attachments = new ArrayList<>();
+        Attachment attachment = new Attachment();
+        attachment.setColor(color);
+        attachment.setBlocks(data);
+        attachments.add(attachment);
+        return attachments;
+    }
+
+    public static List<LayoutBlock> createProdErrorMessage(Exception exception) {
+        StackTraceElement[] stacks = exception.getStackTrace();
+
+        List<LayoutBlock> layoutBlockList = new ArrayList<>();
+
+        List<TextObject> sectionInFields = new ArrayList<>();
+        sectionInFields.add(markdownText(ERROR_MESSAGE + exception.getMessage()));
+        sectionInFields.add(markdownText(ERROR_STACK + exception));
+        layoutBlockList.add(section(section -> section.fields(sectionInFields)));
+
+        layoutBlockList.add(divider());
+        layoutBlockList.add(section(section -> section.text(markdownText(filterErrorStack(stacks)))));
+        return layoutBlockList;
+    }
+
+    private static String filterErrorStack(StackTraceElement[] stacks) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("```");
+        for (StackTraceElement stack : stacks) {
+            if (stack.toString().contains(FILTER_STRING)) {
+                stringBuilder.append(stack).append("\n");
+            }
+        }
+        stringBuilder.append("```");
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,8 @@ spring:
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+slack:
+  token: ${SLACK_TOKEN_DEV}
+  channel:
+    monitor: '#server-error-dev'


### PR DESCRIPTION
## 🔎 Description
> Slack API를 활용하여 서버 에러를 모니터링합니다.
ExceptionAdvice에서 INTERNAL_SERVER_ERROR가 발생할 때, slack의 dev 채널에 관련 알림이 전송됩니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/43](https://github.com/Central-MakeUs/Easybud-Server/issues/43)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
