### PR TITLE
[Feat/#51] 가용자금 조회 서비스 로직 수정

### DIFF
--- a/src/main/java/com/friends/easybud/card/repository/CardRepository.java
+++ b/src/main/java/com/friends/easybud/card/repository/CardRepository.java
@@ -1,7 +1,11 @@
 package com.friends.easybud.card.repository;
 
 import com.friends.easybud.card.domain.Card;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
+
+    List<Card> findByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/friends/easybud/transaction/repository/AccountRepository.java
+++ b/src/main/java/com/friends/easybud/transaction/repository/AccountRepository.java
@@ -2,7 +2,9 @@ package com.friends.easybud.transaction.repository;
 
 import com.friends.easybud.transaction.domain.Account;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,16 +18,16 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             "JOIN tc.secondaryCategory sc " +
             "JOIN sc.primaryCategory pc " +
             "WHERE pc.content = :content AND t.member.id = :memberId")
-    BigDecimal sumOfAccountsByPrimaryCategoryContentAndMemberId(@Param("content") String content,
-                                                                @Param("memberId") Long memberId);
+    Optional<BigDecimal> sumOfAccountsByPrimaryCategoryContentAndMemberId(@Param("content") String content,
+                                                                          @Param("memberId") Long memberId);
 
     @Query("SELECT SUM(a.amount) FROM Account a " +
             "JOIN a.transaction t " +
             "JOIN a.tertiaryCategory tc " +
             "JOIN tc.secondaryCategory sc " +
             "WHERE sc.content = :content AND t.member.id = :memberId")
-    BigDecimal sumOfAccountsBySecondaryCategoryContentAndMemberId(@Param("content") String content,
-                                                                  @Param("memberId") Long memberId);
+    Optional<BigDecimal> sumOfAccountsBySecondaryCategoryContentAndMemberId(@Param("content") String content,
+                                                                            @Param("memberId") Long memberId);
 
     @Query("SELECT SUM(a.amount) FROM Account a " +
             "JOIN a.transaction t " +
@@ -35,7 +37,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             "WHERE pc.content LIKE '수익%' " +
             "AND t.member.id = :memberId " +
             "AND t.date BETWEEN :startDate AND :endDate")
-    BigDecimal sumOfRevenueAccountsByMemberIdAndTransactionDateRangeWithLike(
+    Optional<BigDecimal> sumOfRevenueAccountsByMemberIdAndTransactionDateRangeWithLike(
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);
@@ -48,9 +50,18 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             "WHERE pc.content = '비용' " +
             "AND t.member.id = :memberId " +
             "AND t.date BETWEEN :startDate AND :endDate")
-    BigDecimal sumOfExpenseAccountsByMemberIdAndTransactionDateRange(
+    Optional<BigDecimal> sumOfExpenseAccountsByMemberIdAndTransactionDateRange(
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT SUM(a.amount) FROM Account a " +
+            "WHERE a.card.id = :cardId " +
+            "AND a.transaction.date >= :startDate " +
+            "AND a.transaction.date <= :endDate")
+    Optional<BigDecimal> sumOfTransactionsByCardIdAndDateRange(
+            @Param("cardId") Long cardId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 
 }


### PR DESCRIPTION
## 🔎 Description
> 가용자금 조회 서비스 로직을 수정하였습니다.
**`카드 사용 시작일`**, **`카드 사용 종료일`**, **`카드 대금 지급일`** 세 가지 값을 활용하여, 기존과는 다른 방식으로 가용자금을 계산했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/51](https://github.com/Central-MakeUs/Easybud-Server/issues/51)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
