### PR TITLE
[Feat/#60] Redis 기반의 Refresh Token 재발급 및 저장 로직 구현

### DIFF
--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.friends.easybud.auth.service.KakaoOauthService;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.jwt.dto.JwtToken;
 import com.friends.easybud.member.service.MemberCommandService;
+import com.friends.easybud.redis.RedisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +26,7 @@ public class AuthController {
 
     private final KakaoOauthService kakaoOauthService;
     private final MemberCommandService memberCommandService;
+    private final RedisService redisService;
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
     @PatchMapping("/reissue")

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -2,18 +2,17 @@ package com.friends.easybud.auth.controller;
 
 import com.friends.easybud.auth.dto.KakaoUserInfo;
 import com.friends.easybud.auth.dto.OIDCDecodePayload;
+import com.friends.easybud.auth.service.AuthService;
 import com.friends.easybud.auth.service.KakaoOauthService;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.jwt.dto.JwtToken;
 import com.friends.easybud.member.service.MemberCommandService;
-import com.friends.easybud.redis.RedisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,12 +25,13 @@ public class AuthController {
 
     private final KakaoOauthService kakaoOauthService;
     private final MemberCommandService memberCommandService;
-    private final RedisService redisService;
+    private final AuthService authService;
+
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
     @PatchMapping("/reissue")
-    public ResponseDto<JwtToken> reissue(HttpServletRequest request, HttpServletResponse response) {
-        return ResponseDto.onSuccess(null);
+    public ResponseDto<JwtToken> reissue(@RequestBody String refreshToken) {
+        return ResponseDto.onSuccess(authService.reissueToken(refreshToken));
     }
 
     @Operation(summary = "카카오 ID 토큰 검증", description = "카카오 ID 토큰의 유효성을 검증합니다.")

--- a/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
@@ -27,7 +27,8 @@ public enum ErrorStatus implements BaseCode {
     TOKEN_INVALID(BAD_REQUEST, 4100, "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(BAD_REQUEST, 4101, "만료된 토큰입니다."),
     TOKEN_UNSUPPORTED(BAD_REQUEST, 4102, "지원되지 않는 토큰 형식입니다."),
-    TOKEN_CLAIMS_EMPTY(BAD_REQUEST, 4103, "토큰 클레이밍 비어있습니다."),
+    TOKEN_CLAIMS_EMPTY(BAD_REQUEST, 4103, "토큰 클레임이 비어있습니다."),
+    REFRESH_TOKEN_NOT_FOUND(BAD_REQUEST, 4104, "헤더에 refresh token이 존재하지 않습니다."),
 
     // AccountCategory: 4150 ~ 4199
     PRIMARY_CATEGORY_NOT_FOUND(NOT_FOUND, 4150, "존재하지 않는 계정 대분류입니다."),

--- a/src/main/java/com/friends/easybud/redis/RedisConfig.java
+++ b/src/main/java/com/friends/easybud/redis/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.friends.easybud.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/friends/easybud/redis/RedisService.java
+++ b/src/main/java/com/friends/easybud/redis/RedisService.java
@@ -22,4 +22,8 @@ public class RedisService {
         return values.get(token);
     }
 
+    public void deleteValue(String token) {
+        redisTemplate.delete(token);
+    }
+
 }

--- a/src/main/java/com/friends/easybud/redis/RedisService.java
+++ b/src/main/java/com/friends/easybud/redis/RedisService.java
@@ -1,0 +1,25 @@
+package com.friends.easybud.redis;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate redisTemplate;
+
+    public void setValue(String token, String value, long expireInMillis) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(token, value, Duration.ofMillis(expireInMillis));
+    }
+
+    public String getValue(String token) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(token);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,15 @@ spring:
         default_batch_fetch_size: 100
         dialect: org.hibernate.dialect.MySQLDialect
 
+  data:
+    redis:
+      host: ${REDIS_HOSTNAME}
+      port: ${REDIS_PORT}
+      
 oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}
     app-key: ${KAKAO_APP_KEY}
-
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,10 @@ spring:
         default_batch_fetch_size: 100
         dialect: org.hibernate.dialect.MySQLDialect
 
-  data:
-    redis:
-      host: ${REDIS_HOSTNAME}
-      port: ${REDIS_PORT}
-      
+  redis:
+    host: ${REDIS_HOSTNAME}
+    port: ${REDIS_PORT}
+
 oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}


### PR DESCRIPTION
## 🔎 Description
> AWS ElastiCache를 사용하여 Redis 인스턴스를 구축하고, 이 저장소에서 Refresh Token을 재발급하고 저장하는 로직을 구현했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/60](https://github.com/Central-MakeUs/Easybud-Server/issues/60)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
