### PR TITLE
[Feat/#75] 계정 조회 API 차대변 분리

### DIFF
--- a/src/main/java/com/friends/easybud/transaction/converter/TransactionConverter.java
+++ b/src/main/java/com/friends/easybud/transaction/converter/TransactionConverter.java
@@ -2,7 +2,11 @@ package com.friends.easybud.transaction.converter;
 
 import static com.friends.easybud.transaction.dto.TransactionResponse.TransactionDto;
 
+import com.friends.easybud.global.exception.GeneralException;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.transaction.domain.Account;
+import com.friends.easybud.transaction.domain.AccountState;
+import com.friends.easybud.transaction.domain.AccountType;
 import com.friends.easybud.transaction.domain.Transaction;
 import com.friends.easybud.transaction.dto.TransactionResponse.AccountDto;
 import com.friends.easybud.transaction.dto.TransactionResponse.TransactionListDto;
@@ -19,7 +23,13 @@ public class TransactionConverter {
     }
 
     public static TransactionDto toTransactionDto(Transaction transaction) {
-        List<AccountDto> accountDtos = transaction.getAccounts().stream()
+        List<AccountDto> debitAccounts = transaction.getAccounts().stream()
+                .filter(account -> isDebitAccount(account.getAccountType())) // 차변 계정인지 확인
+                .map(TransactionConverter::toAccountDto)
+                .collect(Collectors.toList());
+
+        List<AccountDto> creditAccounts = transaction.getAccounts().stream()
+                .filter(account -> !isDebitAccount(account.getAccountType())) // 대변 계정인지 확인
                 .map(TransactionConverter::toAccountDto)
                 .collect(Collectors.toList());
 
@@ -28,7 +38,8 @@ public class TransactionConverter {
                 .date(transaction.getDate())
                 .summary(transaction.getSummary())
                 .type(transaction.getType())
-                .accounts(accountDtos)
+                .debitAccounts(debitAccounts)
+                .creditAccounts(creditAccounts)
                 .build();
     }
 
@@ -45,5 +56,22 @@ public class TransactionConverter {
                 .tertiaryCategoryContent(account.getTertiaryCategory().getContent())
                 .amount(account.getAmount()).build();
     }
+
+    private static boolean isDebitAccount(AccountType accountType) {
+        switch (accountType.getTypeName()) {
+            case ASSET:
+                return accountType.getTypeState() == AccountState.INCREASE;
+            case LIABILITY:
+            case EQUITY:
+                return accountType.getTypeState() == AccountState.DECREASE;
+            case EXPENSE:
+                return accountType.getTypeState() == AccountState.OCCURRENCE;
+            case REVENUE:
+                return false; // 수익은 항상 대변
+            default:
+                throw new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND);
+        }
+    }
+
 
 }

--- a/src/main/java/com/friends/easybud/transaction/dto/TransactionResponse.java
+++ b/src/main/java/com/friends/easybud/transaction/dto/TransactionResponse.java
@@ -51,8 +51,11 @@ public class TransactionResponse {
         @Schema(description = "거래 유형", example = "EXPENSE_TRANSACTION")
         private TransactionType type;
 
-        @ArraySchema(schema = @Schema(description = "계정 목록", implementation = AccountDto.class))
-        private List<AccountDto> accounts;
+        @ArraySchema(schema = @Schema(description = "차변 계정 목록", implementation = AccountDto.class))
+        private List<AccountDto> debitAccounts;
+
+        @ArraySchema(schema = @Schema(description = "대변 계정 목록", implementation = AccountDto.class))
+        private List<AccountDto> creditAccounts;
 
     }
 


### PR DESCRIPTION
## 🔎 Description
> 기존 계정 조회 API에서는 차변과 대변 계정 정보가 구분되지 않고 통합되어 있었습니다. 이를 차변과 대변 계정으로 명확히 분리하였습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/75](https://github.com/Central-MakeUs/Easybud-Server/issues/75)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
