### PR TITLE
[Feat/#85] 로그아웃 및 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.friends.easybud.auth.controller;
 import com.friends.easybud.auth.dto.IdTokenRequest;
 import com.friends.easybud.auth.dto.RefreshTokenRequest;
 import com.friends.easybud.auth.service.AuthService;
-import com.friends.easybud.global.annotation.AuthUser;
+import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.jwt.JwtDto;
 import com.friends.easybud.jwt.JwtProvider;
@@ -51,7 +51,7 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @PostMapping("/withdrawal")
-    public ResponseDto<Boolean> withdrawal(@AuthUser Member member) {
+    public ResponseDto<Boolean> withdrawal(@AuthMember Member member) {
         return ResponseDto.onSuccess(memberCommandService.withdrawal(member));
     }
 

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.friends.easybud.auth.controller;
 import com.friends.easybud.auth.dto.IdTokenRequest;
 import com.friends.easybud.auth.dto.RefreshTokenRequest;
 import com.friends.easybud.auth.service.AuthService;
+import com.friends.easybud.global.annotation.AuthUser;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.jwt.JwtDto;
 import com.friends.easybud.jwt.JwtProvider;
@@ -50,7 +51,7 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @PostMapping("/withdrawal")
-    public ResponseDto<Boolean> withdrawal(@RequestBody Member member) {
+    public ResponseDto<Boolean> withdrawal(@AuthUser Member member) {
         return ResponseDto.onSuccess(memberCommandService.withdrawal(member));
     }
 

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -39,4 +39,10 @@ public class AuthController {
         return ResponseDto.onSuccess(authService.socialLogin(provider, request));
     }
 
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ResponseDto<Boolean> logout(@RequestBody RefreshTokenRequest request) {
+        return ResponseDto.onSuccess(jwtTokenProvider.logout(request.getRefreshToken()));
+    }
+
 }

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -4,8 +4,8 @@ import com.friends.easybud.auth.dto.IdTokenRequest;
 import com.friends.easybud.auth.dto.RefreshTokenRequest;
 import com.friends.easybud.auth.service.AuthService;
 import com.friends.easybud.global.response.ResponseDto;
-import com.friends.easybud.jwt.dto.JwtToken;
-import com.friends.easybud.jwt.service.JwtTokenProvider;
+import com.friends.easybud.jwt.JwtDto;
+import com.friends.easybud.jwt.JwtProvider;
 import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.SocialProvider;
 import com.friends.easybud.member.service.MemberCommandService;
@@ -25,27 +25,27 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Auth API", description = "사용자 API")
 public class AuthController {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
     private final AuthService authService;
     private final MemberCommandService memberCommandService;
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
     @PatchMapping("/reissue")
-    public ResponseDto<JwtToken> reissue(@RequestBody RefreshTokenRequest request) {
-        return ResponseDto.onSuccess(jwtTokenProvider.reissueToken(request));
+    public ResponseDto<JwtDto> reissue(@RequestBody RefreshTokenRequest request) {
+        return ResponseDto.onSuccess(jwtProvider.reissueToken(request));
     }
 
     @Operation(summary = "소셜 로그인", description = "소셜로그인을 진행하고 토큰을 발급합니다.")
     @PostMapping("/social-login")
-    public ResponseDto<JwtToken> socialLogin(@RequestParam(name = "provider") SocialProvider provider,
-                                             @RequestBody IdTokenRequest request) {
+    public ResponseDto<JwtDto> socialLogin(@RequestParam(name = "provider") SocialProvider provider,
+                                           @RequestBody IdTokenRequest request) {
         return ResponseDto.onSuccess(authService.socialLogin(provider, request));
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     @PostMapping("/logout")
     public ResponseDto<Boolean> logout(@RequestBody RefreshTokenRequest request) {
-        return ResponseDto.onSuccess(jwtTokenProvider.logout(request.getRefreshToken()));
+        return ResponseDto.onSuccess(jwtProvider.logout(request.getRefreshToken()));
     }
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -6,7 +6,9 @@ import com.friends.easybud.auth.service.AuthService;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.jwt.dto.JwtToken;
 import com.friends.easybud.jwt.service.JwtTokenProvider;
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.SocialProvider;
+import com.friends.easybud.member.service.MemberCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @RestController
-@Tag(name = "Auth API", description = "사용자 인증 API")
+@Tag(name = "Auth API", description = "사용자 API")
 public class AuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthService authService;
+    private final MemberCommandService memberCommandService;
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
     @PatchMapping("/reissue")
@@ -43,6 +46,12 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseDto<Boolean> logout(@RequestBody RefreshTokenRequest request) {
         return ResponseDto.onSuccess(jwtTokenProvider.logout(request.getRefreshToken()));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
+    @PostMapping("/withdrawal")
+    public ResponseDto<Boolean> withdrawal(@RequestBody Member member) {
+        return ResponseDto.onSuccess(memberCommandService.withdrawal(member));
     }
 
 }

--- a/src/main/java/com/friends/easybud/auth/service/AuthService.java
+++ b/src/main/java/com/friends/easybud/auth/service/AuthService.java
@@ -1,11 +1,11 @@
 package com.friends.easybud.auth.service;
 
 import com.friends.easybud.auth.dto.IdTokenRequest;
-import com.friends.easybud.jwt.dto.JwtToken;
+import com.friends.easybud.jwt.JwtDto;
 import com.friends.easybud.member.domain.SocialProvider;
 
 public interface AuthService {
 
-    JwtToken socialLogin(SocialProvider provider, IdTokenRequest request);
+    JwtDto socialLogin(SocialProvider provider, IdTokenRequest request);
 
 }

--- a/src/main/java/com/friends/easybud/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/friends/easybud/auth/service/AuthServiceImpl.java
@@ -5,8 +5,8 @@ import com.friends.easybud.auth.dto.OIDCDecodePayload;
 import com.friends.easybud.auth.dto.OIDCPublicKeysResponse;
 import com.friends.easybud.auth.dto.OauthProperties;
 import com.friends.easybud.auth.feign.KakaoOauthClient;
-import com.friends.easybud.jwt.dto.JwtToken;
-import com.friends.easybud.jwt.service.JwtTokenProvider;
+import com.friends.easybud.jwt.JwtDto;
+import com.friends.easybud.jwt.JwtProvider;
 import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.Role;
 import com.friends.easybud.member.domain.SocialProvider;
@@ -26,11 +26,11 @@ public class AuthServiceImpl implements AuthService {
     private final OauthProperties oauthProperties;
     private final KakaoOauthClient kakaoOauthClient;
     private final OauthOIDCService oauthOIDCService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
 
     @Override
-    public JwtToken socialLogin(SocialProvider provider, IdTokenRequest request) {
+    public JwtDto socialLogin(SocialProvider provider, IdTokenRequest request) {
         OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(provider, request.getIdToken());
         Member member = memberRepository.findByEmailAndSocialProvider(oidcDecodePayload.getEmail(),
                         provider)
@@ -43,7 +43,7 @@ public class AuthServiceImpl implements AuthService {
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        return jwtTokenProvider.generateToken(authentication);
+        return jwtProvider.generateToken(authentication);
     }
 
     private Member register(SocialProvider provider, OIDCDecodePayload oidcDecodePayload) {

--- a/src/main/java/com/friends/easybud/card/controller/CardController.java
+++ b/src/main/java/com/friends/easybud/card/controller/CardController.java
@@ -7,7 +7,9 @@ import com.friends.easybud.card.dto.CardResponse.CardDto;
 import com.friends.easybud.card.dto.CardResponse.CardListDto;
 import com.friends.easybud.card.service.CardCommandService;
 import com.friends.easybud.card.service.CardQueryService;
+import com.friends.easybud.global.annotation.AuthUser;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -31,32 +33,33 @@ public class CardController {
 
     @Operation(summary = "카드 생성", description = "새로운 카드를 생성합니다.")
     @PostMapping
-    public ResponseDto<Long> createCard(@RequestBody CardCreateDto request) {
-        return ResponseDto.onSuccess(cardCommandService.createCard(request));
+    public ResponseDto<Long> createCard(@AuthUser Member member, @RequestBody CardCreateDto request) {
+        return ResponseDto.onSuccess(cardCommandService.createCard(member, request));
     }
 
     @Operation(summary = "카드 삭제", description = "기존의 카드를 삭제합니다.")
     @DeleteMapping("/{cardId}")
-    public ResponseDto<Boolean> deleteCard(@PathVariable Long cardId) {
-        return ResponseDto.onSuccess(cardCommandService.deleteCard(cardId));
+    public ResponseDto<Boolean> deleteCard(@AuthUser Member member, @PathVariable Long cardId) {
+        return ResponseDto.onSuccess(cardCommandService.deleteCard(member, cardId));
     }
 
     @Operation(summary = "카드 수정", description = "기존의 카드를 수정합니다.")
     @PutMapping("/{cardId}")
-    public ResponseDto<Long> updateCard(@PathVariable Long cardId, @RequestBody CardUpdateDto request) {
-        return ResponseDto.onSuccess(cardCommandService.updateCard(cardId, request));
+    public ResponseDto<Long> updateCard(@AuthUser Member member, @PathVariable Long cardId,
+                                        @RequestBody CardUpdateDto request) {
+        return ResponseDto.onSuccess(cardCommandService.updateCard(member, cardId, request));
     }
 
     @Operation(summary = "카드 조회", description = "특정 카드를 조회합니다.")
     @GetMapping("/{cardId}")
-    public ResponseDto<CardDto> getCard(@PathVariable Long cardId) {
-        return ResponseDto.onSuccess(CardConverter.toCardDto(cardQueryService.getCard(cardId)));
+    public ResponseDto<CardDto> getCard(@AuthUser Member member, @PathVariable Long cardId) {
+        return ResponseDto.onSuccess(CardConverter.toCardDto(cardQueryService.getCard(member, cardId)));
     }
 
     @Operation(summary = "카드 목록 조회", description = "특정 회원의 카드 목록을 조회합니다.")
     @GetMapping
-    public ResponseDto<CardListDto> getCards() {
-        return ResponseDto.onSuccess(CardConverter.toCardListDto(cardQueryService.getCards()));
+    public ResponseDto<CardListDto> getCards(@AuthUser Member member) {
+        return ResponseDto.onSuccess(CardConverter.toCardListDto(cardQueryService.getCards(member)));
     }
 
 }

--- a/src/main/java/com/friends/easybud/card/controller/CardController.java
+++ b/src/main/java/com/friends/easybud/card/controller/CardController.java
@@ -7,7 +7,7 @@ import com.friends.easybud.card.dto.CardResponse.CardDto;
 import com.friends.easybud.card.dto.CardResponse.CardListDto;
 import com.friends.easybud.card.service.CardCommandService;
 import com.friends.easybud.card.service.CardQueryService;
-import com.friends.easybud.global.annotation.AuthUser;
+import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,32 +33,32 @@ public class CardController {
 
     @Operation(summary = "카드 생성", description = "새로운 카드를 생성합니다.")
     @PostMapping
-    public ResponseDto<Long> createCard(@AuthUser Member member, @RequestBody CardCreateDto request) {
+    public ResponseDto<Long> createCard(@AuthMember Member member, @RequestBody CardCreateDto request) {
         return ResponseDto.onSuccess(cardCommandService.createCard(member, request));
     }
 
     @Operation(summary = "카드 삭제", description = "기존의 카드를 삭제합니다.")
     @DeleteMapping("/{cardId}")
-    public ResponseDto<Boolean> deleteCard(@AuthUser Member member, @PathVariable Long cardId) {
+    public ResponseDto<Boolean> deleteCard(@AuthMember Member member, @PathVariable Long cardId) {
         return ResponseDto.onSuccess(cardCommandService.deleteCard(member, cardId));
     }
 
     @Operation(summary = "카드 수정", description = "기존의 카드를 수정합니다.")
     @PutMapping("/{cardId}")
-    public ResponseDto<Long> updateCard(@AuthUser Member member, @PathVariable Long cardId,
+    public ResponseDto<Long> updateCard(@AuthMember Member member, @PathVariable Long cardId,
                                         @RequestBody CardUpdateDto request) {
         return ResponseDto.onSuccess(cardCommandService.updateCard(member, cardId, request));
     }
 
     @Operation(summary = "카드 조회", description = "특정 카드를 조회합니다.")
     @GetMapping("/{cardId}")
-    public ResponseDto<CardDto> getCard(@AuthUser Member member, @PathVariable Long cardId) {
+    public ResponseDto<CardDto> getCard(@AuthMember Member member, @PathVariable Long cardId) {
         return ResponseDto.onSuccess(CardConverter.toCardDto(cardQueryService.getCard(member, cardId)));
     }
 
     @Operation(summary = "카드 목록 조회", description = "특정 회원의 카드 목록을 조회합니다.")
     @GetMapping
-    public ResponseDto<CardListDto> getCards(@AuthUser Member member) {
+    public ResponseDto<CardListDto> getCards(@AuthMember Member member) {
         return ResponseDto.onSuccess(CardConverter.toCardListDto(cardQueryService.getCards(member)));
     }
 

--- a/src/main/java/com/friends/easybud/card/repository/CardRepository.java
+++ b/src/main/java/com/friends/easybud/card/repository/CardRepository.java
@@ -1,11 +1,14 @@
 package com.friends.easybud.card.repository;
 
 import com.friends.easybud.card.domain.Card;
+import com.friends.easybud.member.domain.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
 
     List<Card> findByMemberId(Long memberId);
+
+    void deleteAllByMember(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/card/service/CardCommandService.java
+++ b/src/main/java/com/friends/easybud/card/service/CardCommandService.java
@@ -2,13 +2,14 @@ package com.friends.easybud.card.service;
 
 import com.friends.easybud.card.dto.CardRequest.CardCreateDto;
 import com.friends.easybud.card.dto.CardRequest.CardUpdateDto;
+import com.friends.easybud.member.domain.Member;
 
 public interface CardCommandService {
 
-    Long createCard(CardCreateDto request);
+    Long createCard(Member member, CardCreateDto request);
 
-    Long updateCard(Long cardId, CardUpdateDto request);
+    Long updateCard(Member member, Long cardId, CardUpdateDto request);
 
-    Boolean deleteCard(Long cardId);
+    Boolean deleteCard(Member member, Long cardId);
 
 }

--- a/src/main/java/com/friends/easybud/card/service/CardCommandServiceImpl.java
+++ b/src/main/java/com/friends/easybud/card/service/CardCommandServiceImpl.java
@@ -8,7 +8,6 @@ import com.friends.easybud.card.repository.CardRepository;
 import com.friends.easybud.global.exception.GeneralException;
 import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
-import com.friends.easybud.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,13 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CardCommandServiceImpl implements CardCommandService {
 
-    private final MemberRepository memberRepository;    // TODO MemberQueryService 주입
     private final CardRepository cardRepository;
 
     @Override
-    public Long createCard(CardCreateDto request) {
-        Member member = memberRepository.findById(1L).get();    // TODO 로그인 된 사용자 정보 조회
-
+    public Long createCard(Member member, CardCreateDto request) {
         Card card = buildCard(request, member);
         cardRepository.save(card);
 
@@ -42,9 +38,11 @@ public class CardCommandServiceImpl implements CardCommandService {
     }
 
     @Override
-    public Long updateCard(Long cardId, CardUpdateDto request) {
+    public Long updateCard(Member member, Long cardId, CardUpdateDto request) {
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CARD_NOT_FOUND));
+
+        checkCardOwnership(member, card);
 
         card.update(request);
 
@@ -52,12 +50,21 @@ public class CardCommandServiceImpl implements CardCommandService {
     }
 
     @Override
-    public Boolean deleteCard(Long cardId) {
+    public Boolean deleteCard(Member member, Long cardId) {
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CARD_NOT_FOUND));
+
+        checkCardOwnership(member, card);
+
         // TODO 연관된 Account 처리
         cardRepository.delete(card);
         return Boolean.TRUE;
+    }
+
+    private void checkCardOwnership(Member member, Card card) {
+        if (!card.getMember().equals(member)) {
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED_CARD_ACCESS);
+        }
     }
 
 }

--- a/src/main/java/com/friends/easybud/card/service/CardQueryService.java
+++ b/src/main/java/com/friends/easybud/card/service/CardQueryService.java
@@ -1,12 +1,13 @@
 package com.friends.easybud.card.service;
 
 import com.friends.easybud.card.domain.Card;
+import com.friends.easybud.member.domain.Member;
 import java.util.List;
 
 public interface CardQueryService {
 
-    Card getCard(Long cardId);
+    Card getCard(Member member, Long cardId);
 
-    List<Card> getCards();
+    List<Card> getCards(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/card/service/CardQueryServiceImpl.java
+++ b/src/main/java/com/friends/easybud/card/service/CardQueryServiceImpl.java
@@ -5,7 +5,6 @@ import com.friends.easybud.card.repository.CardRepository;
 import com.friends.easybud.global.exception.GeneralException;
 import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
-import com.friends.easybud.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,18 +15,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CardQueryServiceImpl implements CardQueryService {
 
-    private final MemberRepository memberRepository;    // TODO MemberQueryService 주입
     private final CardRepository cardRepository;
 
     @Override
-    public Card getCard(Long cardId) {
+    public Card getCard(Member member, Long cardId) {
         return cardRepository.findById(cardId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CARD_NOT_FOUND));
     }
 
     @Override
-    public List<Card> getCards() {
-        Member member = memberRepository.findById(1L).get();    // TODO 로그인 된 사용자 정보 조회
+    public List<Card> getCards(Member member) {
         return member.getCards();
     }
 

--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -6,7 +6,7 @@ import com.friends.easybud.category.converter.CategoryConverter;
 import com.friends.easybud.category.dto.CategoryRequest.TertiaryCategoryCreateDto;
 import com.friends.easybud.category.service.CategoryCommandService;
 import com.friends.easybud.category.service.CategoryQueryService;
-import com.friends.easybud.global.annotation.AuthUser;
+import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,7 +32,7 @@ public class CategoryController {
 
     @Operation(summary = "계정 소분류 생성", description = "새로운 소분류를 생성합니다.")
     @PostMapping("/tertiary")
-    public ResponseDto<Long> createTertiaryCategory(@AuthUser Member member,
+    public ResponseDto<Long> createTertiaryCategory(@AuthMember Member member,
                                                     @RequestBody TertiaryCategoryCreateDto request) {
         return ResponseDto.onSuccess(categoryCommandService.createTertiaryCategory(member, request));
     }
@@ -40,13 +40,14 @@ public class CategoryController {
     @Operation(summary = "계정 소분류 삭제", description = "기존의 소분류를 삭제합니다.")
     @Parameter(name = "tertiaryCategoryId", description = "삭제할 소분류의 ID")
     @DeleteMapping("/tertiary/{tertiaryCategoryId}")
-    public ResponseDto<Boolean> deleteTertiaryCategory(@AuthUser Member member, @PathVariable Long tertiaryCategoryId) {
+    public ResponseDto<Boolean> deleteTertiaryCategory(@AuthMember Member member,
+                                                       @PathVariable Long tertiaryCategoryId) {
         return ResponseDto.onSuccess(categoryCommandService.deleteTertiaryCategory(member, tertiaryCategoryId));
     }
 
     @Operation(summary = "계정 카테고리 목록 조회", description = "로그인 된 회원의 계정 카테고리 목록을 조회합니다.")
     @GetMapping
-    public ResponseDto<AccountCategoryListDto> getAccountCategories(@AuthUser Member member) {
+    public ResponseDto<AccountCategoryListDto> getAccountCategories(@AuthMember Member member) {
         return ResponseDto.onSuccess(
                 CategoryConverter.toAccountCategoryListDto(categoryQueryService.getTertiaryCategories(member)));
     }

--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -6,7 +6,9 @@ import com.friends.easybud.category.converter.CategoryConverter;
 import com.friends.easybud.category.dto.CategoryRequest.TertiaryCategoryCreateDto;
 import com.friends.easybud.category.service.CategoryCommandService;
 import com.friends.easybud.category.service.CategoryQueryService;
+import com.friends.easybud.global.annotation.AuthUser;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,22 +32,23 @@ public class CategoryController {
 
     @Operation(summary = "계정 소분류 생성", description = "새로운 소분류를 생성합니다.")
     @PostMapping("/tertiary")
-    public ResponseDto<Long> createTertiaryCategory(@RequestBody TertiaryCategoryCreateDto request) {
-        return ResponseDto.onSuccess(categoryCommandService.createTertiaryCategory(request));
+    public ResponseDto<Long> createTertiaryCategory(@AuthUser Member member,
+                                                    @RequestBody TertiaryCategoryCreateDto request) {
+        return ResponseDto.onSuccess(categoryCommandService.createTertiaryCategory(member, request));
     }
 
     @Operation(summary = "계정 소분류 삭제", description = "기존의 소분류를 삭제합니다.")
     @Parameter(name = "tertiaryCategoryId", description = "삭제할 소분류의 ID")
     @DeleteMapping("/tertiary/{tertiaryCategoryId}")
-    public ResponseDto<Boolean> deleteTertiaryCategory(@PathVariable Long tertiaryCategoryId) {
-        return ResponseDto.onSuccess(categoryCommandService.deleteTertiaryCategory(tertiaryCategoryId));
+    public ResponseDto<Boolean> deleteTertiaryCategory(@AuthUser Member member, @PathVariable Long tertiaryCategoryId) {
+        return ResponseDto.onSuccess(categoryCommandService.deleteTertiaryCategory(member, tertiaryCategoryId));
     }
 
     @Operation(summary = "계정 카테고리 목록 조회", description = "로그인 된 회원의 계정 카테고리 목록을 조회합니다.")
     @GetMapping
-    public ResponseDto<AccountCategoryListDto> getAccountCategories() {
+    public ResponseDto<AccountCategoryListDto> getAccountCategories(@AuthUser Member member) {
         return ResponseDto.onSuccess(
-                CategoryConverter.toAccountCategoryListDto(categoryQueryService.getTertiaryCategories(1L)));
+                CategoryConverter.toAccountCategoryListDto(categoryQueryService.getTertiaryCategories(member)));
     }
 
 }

--- a/src/main/java/com/friends/easybud/category/repository/TertiaryCategoryRepository.java
+++ b/src/main/java/com/friends/easybud/category/repository/TertiaryCategoryRepository.java
@@ -1,11 +1,14 @@
 package com.friends.easybud.category.repository;
 
 import com.friends.easybud.category.domain.TertiaryCategory;
+import com.friends.easybud.member.domain.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TertiaryCategoryRepository extends JpaRepository<TertiaryCategory, Long> {
 
     List<TertiaryCategory> findByMemberIdOrIsDefaultTrue(Long memberId);
+
+    void deleteAllByMember(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/category/service/CategoryCommandService.java
+++ b/src/main/java/com/friends/easybud/category/service/CategoryCommandService.java
@@ -2,10 +2,12 @@ package com.friends.easybud.category.service;
 
 import static com.friends.easybud.category.dto.CategoryRequest.TertiaryCategoryCreateDto;
 
+import com.friends.easybud.member.domain.Member;
+
 public interface CategoryCommandService {
 
-    Long createTertiaryCategory(TertiaryCategoryCreateDto request);
+    Long createTertiaryCategory(Member member, TertiaryCategoryCreateDto request);
 
-    Boolean deleteTertiaryCategory(Long accountCategoryId);
+    Boolean deleteTertiaryCategory(Member member, Long accountCategoryId);
 
 }

--- a/src/main/java/com/friends/easybud/category/service/CategoryQueryService.java
+++ b/src/main/java/com/friends/easybud/category/service/CategoryQueryService.java
@@ -1,10 +1,11 @@
 package com.friends.easybud.category.service;
 
 import com.friends.easybud.category.domain.TertiaryCategory;
+import com.friends.easybud.member.domain.Member;
 import java.util.List;
 
 public interface CategoryQueryService {
 
-    List<TertiaryCategory> getTertiaryCategories(Long memberId);
+    List<TertiaryCategory> getTertiaryCategories(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/friends/easybud/category/service/CategoryQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.friends.easybud.category.service;
 
 import com.friends.easybud.category.domain.TertiaryCategory;
 import com.friends.easybud.category.repository.TertiaryCategoryRepository;
+import com.friends.easybud.member.domain.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,8 +16,8 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
     private final TertiaryCategoryRepository tertiaryCategoryRepository;
 
     @Override
-    public List<TertiaryCategory> getTertiaryCategories(Long memberId) {
-        return tertiaryCategoryRepository.findByMemberIdOrIsDefaultTrue(memberId);
+    public List<TertiaryCategory> getTertiaryCategories(Member member) {
+        return tertiaryCategoryRepository.findByMemberIdOrIsDefaultTrue(member.getId());
     }
 
 }

--- a/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
+++ b/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
@@ -8,7 +8,9 @@ import com.friends.easybud.financial.converter.FinancialConverter;
 import com.friends.easybud.financial.dto.FinancialResponse.IncomeStatementSummaryDto;
 import com.friends.easybud.financial.dto.FinancialResponse.ProfitLossListDto;
 import com.friends.easybud.financial.service.FinancialService;
+import com.friends.easybud.global.annotation.AuthUser;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,49 +34,53 @@ public class FinancialController {
 
     @Operation(summary = "가용자금 조회", description = "사용자의 가용자금을 조회합니다.")
     @GetMapping("/available-funds")
-    public ResponseDto<AvailableFundsDto> getAvailableFunds() {
-        return ResponseDto.onSuccess(financialService.getAvailableFunds());
+    public ResponseDto<AvailableFundsDto> getAvailableFunds(@AuthUser Member member) {
+        return ResponseDto.onSuccess(financialService.getAvailableFunds(member));
     }
 
     @Operation(summary = "재무 상태 조회", description = "사용자의 재무 상태를 조회합니다.")
     @GetMapping("/financial-statement")
-    public ResponseDto<FinancialStatementDto> getFinancialStatement() {
-        return ResponseDto.onSuccess(financialService.getFinancialStatement());
+    public ResponseDto<FinancialStatementDto> getFinancialStatement(@AuthUser Member member) {
+        return ResponseDto.onSuccess(financialService.getFinancialStatement(member));
     }
 
     @Operation(summary = "손익현황 조회", description = "사용자의 손익현황을 조회합니다.")
     @Parameter(name = "startDate", example = "2024-02-01")
     @Parameter(name = "endDate", example = "2024-02-02")
     @GetMapping("/income-statement")
-    public ResponseDto<IncomeStatementDto> getIncomeStatement(@RequestParam LocalDate startDate,
+    public ResponseDto<IncomeStatementDto> getIncomeStatement(@AuthUser Member member,
+                                                              @RequestParam LocalDate startDate,
                                                               @RequestParam LocalDate endDate) {
         LocalDateTime startOfDay = startDate.atStartOfDay();
         LocalDateTime endOfDay = endDate.atTime(23, 59, 59);
-        return ResponseDto.onSuccess(financialService.getIncomeStatement(startOfDay, endOfDay));
+        return ResponseDto.onSuccess(financialService.getIncomeStatement(member, startOfDay, endOfDay));
     }
 
     @Operation(summary = "월간 손익현황 요약 조회", description = "특정 연도와 월에 대한 손익현황을 조회합니다.")
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")
     @GetMapping("/income-statement/summary/monthly")
-    public ResponseDto<IncomeStatementSummaryDto> getMonthlyIncomeStatementSummary(@RequestParam int year,
+    public ResponseDto<IncomeStatementSummaryDto> getMonthlyIncomeStatementSummary(@AuthUser Member member,
+                                                                                   @RequestParam int year,
                                                                                    @RequestParam int month) {
         LocalDateTime startOfMonth = LocalDateTime.of(year, month, 1, 0, 0, 0);
         LocalDateTime endOfMonth = YearMonth.of(year, month)
                 .atEndOfMonth()
                 .atTime(LocalTime.MAX)
                 .withNano(0);
-        return ResponseDto.onSuccess(financialService.getIncomeStatementSummary(startOfMonth, endOfMonth));
+        return ResponseDto.onSuccess(financialService.getIncomeStatementSummary(member, startOfMonth, endOfMonth));
     }
 
     @Operation(summary = "월간 일별 손익현황 요약 조회", description = "특정 연도와 월에 대해 해당 월의 모든 일자별 손익현황을 조회합니다.")
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")
     @GetMapping("/income-statement/summary/daily")
-    public ResponseDto<ProfitLossListDto> getDailyIncomeStatementSummary(@RequestParam int year,
+    public ResponseDto<ProfitLossListDto> getDailyIncomeStatementSummary(@AuthUser Member member,
+                                                                         @RequestParam int year,
                                                                          @RequestParam int month) {
         return ResponseDto.onSuccess(
-                FinancialConverter.toProfitLossListDto(financialService.getDailyIncomeStatementSummaries(year, month)));
+                FinancialConverter.toProfitLossListDto(
+                        financialService.getDailyIncomeStatementSummaries(member, year, month)));
     }
 
 

--- a/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
+++ b/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
@@ -8,7 +8,7 @@ import com.friends.easybud.financial.converter.FinancialConverter;
 import com.friends.easybud.financial.dto.FinancialResponse.IncomeStatementSummaryDto;
 import com.friends.easybud.financial.dto.FinancialResponse.ProfitLossListDto;
 import com.friends.easybud.financial.service.FinancialService;
-import com.friends.easybud.global.annotation.AuthUser;
+import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,13 +34,13 @@ public class FinancialController {
 
     @Operation(summary = "가용자금 조회", description = "사용자의 가용자금을 조회합니다.")
     @GetMapping("/available-funds")
-    public ResponseDto<AvailableFundsDto> getAvailableFunds(@AuthUser Member member) {
+    public ResponseDto<AvailableFundsDto> getAvailableFunds(@AuthMember Member member) {
         return ResponseDto.onSuccess(financialService.getAvailableFunds(member));
     }
 
     @Operation(summary = "재무 상태 조회", description = "사용자의 재무 상태를 조회합니다.")
     @GetMapping("/financial-statement")
-    public ResponseDto<FinancialStatementDto> getFinancialStatement(@AuthUser Member member) {
+    public ResponseDto<FinancialStatementDto> getFinancialStatement(@AuthMember Member member) {
         return ResponseDto.onSuccess(financialService.getFinancialStatement(member));
     }
 
@@ -48,7 +48,7 @@ public class FinancialController {
     @Parameter(name = "startDate", example = "2024-02-01")
     @Parameter(name = "endDate", example = "2024-02-02")
     @GetMapping("/income-statement")
-    public ResponseDto<IncomeStatementDto> getIncomeStatement(@AuthUser Member member,
+    public ResponseDto<IncomeStatementDto> getIncomeStatement(@AuthMember Member member,
                                                               @RequestParam LocalDate startDate,
                                                               @RequestParam LocalDate endDate) {
         LocalDateTime startOfDay = startDate.atStartOfDay();
@@ -60,7 +60,7 @@ public class FinancialController {
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")
     @GetMapping("/income-statement/summary/monthly")
-    public ResponseDto<IncomeStatementSummaryDto> getMonthlyIncomeStatementSummary(@AuthUser Member member,
+    public ResponseDto<IncomeStatementSummaryDto> getMonthlyIncomeStatementSummary(@AuthMember Member member,
                                                                                    @RequestParam int year,
                                                                                    @RequestParam int month) {
         LocalDateTime startOfMonth = LocalDateTime.of(year, month, 1, 0, 0, 0);
@@ -75,7 +75,7 @@ public class FinancialController {
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")
     @GetMapping("/income-statement/summary/daily")
-    public ResponseDto<ProfitLossListDto> getDailyIncomeStatementSummary(@AuthUser Member member,
+    public ResponseDto<ProfitLossListDto> getDailyIncomeStatementSummary(@AuthMember Member member,
                                                                          @RequestParam int year,
                                                                          @RequestParam int month) {
         return ResponseDto.onSuccess(

--- a/src/main/java/com/friends/easybud/financial/service/FinancialService.java
+++ b/src/main/java/com/friends/easybud/financial/service/FinancialService.java
@@ -5,19 +5,20 @@ import com.friends.easybud.financial.dto.FinancialResponse.FinancialStatementDto
 import com.friends.easybud.financial.dto.FinancialResponse.IncomeStatementDto;
 import com.friends.easybud.financial.dto.FinancialResponse.IncomeStatementSummaryDto;
 import com.friends.easybud.financial.dto.FinancialResponse.ProfitLossDto;
+import com.friends.easybud.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FinancialService {
 
-    AvailableFundsDto getAvailableFunds();
+    AvailableFundsDto getAvailableFunds(Member member);
 
-    FinancialStatementDto getFinancialStatement();
+    FinancialStatementDto getFinancialStatement(Member member);
 
-    IncomeStatementDto getIncomeStatement(LocalDateTime startDate, LocalDateTime endDate);
+    IncomeStatementDto getIncomeStatement(Member member, LocalDateTime startDate, LocalDateTime endDate);
 
-    IncomeStatementSummaryDto getIncomeStatementSummary(LocalDateTime startDate, LocalDateTime endDate);
+    IncomeStatementSummaryDto getIncomeStatementSummary(Member member, LocalDateTime startDate, LocalDateTime endDate);
 
-    List<ProfitLossDto> getDailyIncomeStatementSummaries(int year, int month);
+    List<ProfitLossDto> getDailyIncomeStatementSummaries(Member member, int year, int month);
 
 }

--- a/src/main/java/com/friends/easybud/global/annotation/AuthMember.java
+++ b/src/main/java/com/friends/easybud/global/annotation/AuthMember.java
@@ -1,5 +1,6 @@
 package com.friends.easybud.global.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,5 +8,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AuthUser {
+@Parameter(hidden = true)
+public @interface AuthMember {
 }

--- a/src/main/java/com/friends/easybud/global/annotation/AuthUser.java
+++ b/src/main/java/com/friends/easybud/global/annotation/AuthUser.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Authuser {
+public @interface AuthUser {
 }

--- a/src/main/java/com/friends/easybud/global/annotation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/friends/easybud/global/annotation/AuthenticationArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.friends.easybud.global.annotation;
+
+import com.friends.easybud.global.exception.GeneralException;
+import com.friends.easybud.global.response.code.ErrorStatus;
+import com.friends.easybud.jwt.JwtProvider;
+import com.friends.easybud.member.domain.Member;
+import com.friends.easybud.member.service.MemberQueryService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final MemberQueryService memberQueryService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        final boolean isRegUserAnnotation = parameter.getParameterAnnotation(Authuser.class) != null;
+        final boolean isMember = parameter.getParameterType().equals(Member.class);
+        return isRegUserAnnotation && isMember;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+            String token = jwtProvider.resolveToken(request);
+            String uid = jwtProvider.getAuthentication(token).getName();
+            return memberQueryService.getMemberByUid(uid);
+        } else {
+            throw new GeneralException(ErrorStatus.TOKEN_INVALID);
+        }
+    }
+}

--- a/src/main/java/com/friends/easybud/global/annotation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/friends/easybud/global/annotation/AuthenticationArgumentResolver.java
@@ -26,7 +26,7 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        final boolean isRegUserAnnotation = parameter.getParameterAnnotation(AuthUser.class) != null;
+        final boolean isRegUserAnnotation = parameter.getParameterAnnotation(AuthMember.class) != null;
         final boolean isMember = parameter.getParameterType().equals(Member.class);
         return isRegUserAnnotation && isMember;
     }

--- a/src/main/java/com/friends/easybud/global/annotation/Authuser.java
+++ b/src/main/java/com/friends/easybud/global/annotation/Authuser.java
@@ -1,0 +1,11 @@
+package com.friends.easybud.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authuser {
+}

--- a/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
+++ b/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.friends.easybud.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,11 +18,23 @@ public class SwaggerConfig {
                 .version("v0.0.1")
                 .description("Easybud의 API 명세서입니다.");
 
+        String jwtSchemeName = "JWT";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
         Server server = new Server().url("/");
 
         return new OpenAPI()
-                .components(new Components())
+                .components(components)
                 .info(info)
+                .addSecurityItem(securityRequirement)
                 .addServersItem(server);
     }
 }

--- a/src/main/java/com/friends/easybud/global/config/WebConfig.java
+++ b/src/main/java/com/friends/easybud/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.friends.easybud.global.config;
+
+import com.friends.easybud.global.annotation.AuthenticationArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
+    }
+
+}

--- a/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseCode {
     TOKEN_UNSUPPORTED(BAD_REQUEST, 4102, "지원되지 않는 토큰 형식입니다."),
     TOKEN_CLAIMS_EMPTY(BAD_REQUEST, 4103, "토큰 클레임이 비어있습니다."),
     REFRESH_TOKEN_NOT_FOUND(BAD_REQUEST, 4104, "헤더에 refresh token이 존재하지 않습니다."),
+    AUTHENTICATION_REQUIRED(BAD_REQUEST, 4105, "인증 정보가 필요합니다."),
 
     // AccountCategory: 4150 ~ 4199
     PRIMARY_CATEGORY_NOT_FOUND(NOT_FOUND, 4150, "존재하지 않는 계정 대분류입니다."),
@@ -36,12 +37,15 @@ public enum ErrorStatus implements BaseCode {
     TERTIARY_CATEGORY_NOT_FOUND(NOT_FOUND, 4152, "존재하지 않는 계정 소분류입니다."),
     CANNOT_DELETE_DEFAULT_CATEGORY(BAD_REQUEST, 4153, "기본값은 삭제할 수 없습니다."),
     TERTIARY_CATEGORY_ALREADY_EXISTS(BAD_REQUEST, 4154, "이미 존재하는 계정 소분류입니다."),
+    UNAUTHORIZED_TERTIARY_CATEGORY_ACCESS(BAD_REQUEST, 4155, "접근 권한이 없는 소분류입니다."),
 
     // Card: 4200 ~ 4249
     CARD_NOT_FOUND(NOT_FOUND, 4200, "존재하지 않는 카드입니다."),
+    UNAUTHORIZED_CARD_ACCESS(BAD_REQUEST, 4201, "접근 권한이 없는 카드입니다."),
 
     // Transaction: 4250 ~ 4299
     TRANSACTION_NOT_FOUND(NOT_FOUND, 4250, "존재하지 않는 거래입니다."),
+    UNAUTHORIZED_TRANSACTION_ACCESS(BAD_REQUEST, 4251, "접근 권한이 없는 거래입니다."),
 
     // Account: 4300 ~ 4349
     ACCOUNT_NOT_FOUND(NOT_FOUND, 4300, "존재하지 않는 계정입니다."),

--- a/src/main/java/com/friends/easybud/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/friends/easybud/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package com.friends.easybud.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        HttpServletRequest httpServletRequest = ((HttpServletRequest) request);
+        String token = jwtProvider.resolveToken(httpServletRequest);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            SecurityContextHolder.getContext().setAuthentication(null);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/friends/easybud/jwt/JwtDto.java
+++ b/src/main/java/com/friends/easybud/jwt/JwtDto.java
@@ -1,4 +1,4 @@
-package com.friends.easybud.jwt.dto;
+package com.friends.easybud.jwt;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,7 +7,7 @@ import lombok.Data;
 @Builder
 @Data
 @AllArgsConstructor
-public class JwtToken {
+public class JwtDto {
 
     private String grantType;
     private String accessToken;

--- a/src/main/java/com/friends/easybud/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/friends/easybud/jwt/service/JwtTokenProvider.java
@@ -122,4 +122,10 @@ public class JwtTokenProvider {
         }
     }
 
+    public boolean logout(String refreshToken) {
+        redisService.deleteValue(refreshToken);
+        return true;
+    }
+
+
 }

--- a/src/main/java/com/friends/easybud/member/domain/Member.java
+++ b/src/main/java/com/friends/easybud/member/domain/Member.java
@@ -2,9 +2,7 @@ package com.friends.easybud.member.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.friends.easybud.card.domain.Card;
-import com.friends.easybud.category.domain.TertiaryCategory;
 import com.friends.easybud.global.domain.BaseTimeEntity;
-import com.friends.easybud.transaction.domain.Transaction;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -51,16 +49,11 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private Role role;
 
     @OneToMany(mappedBy = "member")
-    private List<Transaction> transactions = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member")
-    private List<TertiaryCategory> tertiaryCategories = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member")
     private List<Card> cards = new ArrayList<>();
 
+
     @Builder
-    public Member(String uid, SocialProvider socialProvider, String email, String name, Role role) {
+    public Member(SocialProvider socialProvider, String email, String name, Role role) {
         this.uid = UUID.randomUUID().toString();
         this.socialProvider = socialProvider;
         this.email = email;

--- a/src/main/java/com/friends/easybud/member/service/MemberCommandService.java
+++ b/src/main/java/com/friends/easybud/member/service/MemberCommandService.java
@@ -1,0 +1,9 @@
+package com.friends.easybud.member.service;
+
+import com.friends.easybud.member.domain.Member;
+
+public interface MemberCommandService {
+
+    boolean withdrawal(Member member);
+
+}

--- a/src/main/java/com/friends/easybud/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/friends/easybud/member/service/MemberCommandServiceImpl.java
@@ -1,0 +1,31 @@
+package com.friends.easybud.member.service;
+
+
+import com.friends.easybud.card.repository.CardRepository;
+import com.friends.easybud.category.repository.TertiaryCategoryRepository;
+import com.friends.easybud.member.domain.Member;
+import com.friends.easybud.member.repository.MemberRepository;
+import com.friends.easybud.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberCommandServiceImpl implements MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final TertiaryCategoryRepository tertiaryCategoryRepository;
+    private final CardRepository cardRepository;
+    private final TransactionRepository transactionRepository;
+
+    @Override
+    public boolean withdrawal(Member member) {
+        tertiaryCategoryRepository.deleteAllByMember(member);
+        cardRepository.deleteAllByMember(member);
+        transactionRepository.deleteAllByMember(member);
+        memberRepository.delete(member);
+        return true;
+    }
+}

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -1,6 +1,6 @@
 package com.friends.easybud.transaction.controller;
 
-import com.friends.easybud.global.annotation.AuthUser;
+import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.converter.TransactionConverter;
@@ -35,21 +35,21 @@ public class TransactionController {
 
     @Operation(summary = "거래 생성", description = "새로운 거래를 생성합니다.")
     @PostMapping
-    public ResponseDto<Long> createTransaction(@AuthUser Member member,
+    public ResponseDto<Long> createTransaction(@AuthMember Member member,
                                                @RequestBody TransactionCreateDto request) {
         return ResponseDto.onSuccess(transactionCommandService.createTransaction(member, request));
     }
 
     @Operation(summary = "거래 삭제", description = "기존의 거래를 삭제합니다.")
     @DeleteMapping("/{transactionId}")
-    public ResponseDto<Boolean> deleteTransaction(@AuthUser Member member,
+    public ResponseDto<Boolean> deleteTransaction(@AuthMember Member member,
                                                   @PathVariable Long transactionId) {
         return ResponseDto.onSuccess(transactionCommandService.deleteTransaction(member, transactionId));
     }
 
     @Operation(summary = "거래 조회", description = "특정 거래를 조회합니다.")
     @GetMapping("/{transactionId}")
-    public ResponseDto<TransactionDto> getTransaction(@AuthUser Member member,
+    public ResponseDto<TransactionDto> getTransaction(@AuthMember Member member,
                                                       @PathVariable Long transactionId) {
         return ResponseDto.onSuccess(
                 TransactionConverter.toTransactionDto(transactionQueryService.getTransaction(member, transactionId)));
@@ -57,7 +57,7 @@ public class TransactionController {
 
     @Operation(summary = "특정 날짜의 거래 조회", description = "주어진 날짜에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/date/{date}")
-    public ResponseDto<TransactionListDto> getTransactionsByDate(@AuthUser Member member,
+    public ResponseDto<TransactionListDto> getTransactionsByDate(@AuthMember Member member,
                                                                  @PathVariable @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(23, 59, 59);
@@ -68,7 +68,7 @@ public class TransactionController {
 
     @Operation(summary = "최근 3개의 거래 조회", description = "가장 최근에 이루어진 3개의 거래를 조회합니다.")
     @GetMapping("/recent")
-    public ResponseDto<TransactionListDto> getRecentTransactions(@AuthUser Member member) {
+    public ResponseDto<TransactionListDto> getRecentTransactions(@AuthMember Member member) {
         return ResponseDto.onSuccess(
                 TransactionConverter.toTransactionListDto(transactionQueryService.getRecentTransactions(member)));
     }
@@ -76,7 +76,7 @@ public class TransactionController {
     @Operation(summary = "특정 연도와 달의 거래 조회", description = "주어진 연도와 달에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/year/{year}/month/{month}")
     public ResponseDto<TransactionListDto> getTransactionsByYearAndMonth(
-            @AuthUser Member member,
+            @AuthMember Member member,
             @PathVariable int year,
             @PathVariable int month) {
         LocalDate startOfMonth = LocalDate.of(year, month, 1);

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -1,6 +1,8 @@
 package com.friends.easybud.transaction.controller;
 
+import com.friends.easybud.global.annotation.AuthUser;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.converter.TransactionConverter;
 import com.friends.easybud.transaction.dto.TransactionRequest.TransactionCreateDto;
 import com.friends.easybud.transaction.dto.TransactionResponse.TransactionDto;
@@ -33,44 +35,48 @@ public class TransactionController {
 
     @Operation(summary = "거래 생성", description = "새로운 거래를 생성합니다.")
     @PostMapping
-    public ResponseDto<Long> createTransaction(@RequestBody TransactionCreateDto request) {
-        return ResponseDto.onSuccess(transactionCommandService.createTransaction(request));
+    public ResponseDto<Long> createTransaction(@AuthUser Member member,
+                                               @RequestBody TransactionCreateDto request) {
+        return ResponseDto.onSuccess(transactionCommandService.createTransaction(member, request));
     }
 
     @Operation(summary = "거래 삭제", description = "기존의 거래를 삭제합니다.")
     @DeleteMapping("/{transactionId}")
-    public ResponseDto<Boolean> deleteTransaction(@PathVariable Long transactionId) {
-        return ResponseDto.onSuccess(transactionCommandService.deleteTransaction(transactionId));
+    public ResponseDto<Boolean> deleteTransaction(@AuthUser Member member,
+                                                  @PathVariable Long transactionId) {
+        return ResponseDto.onSuccess(transactionCommandService.deleteTransaction(member, transactionId));
     }
 
     @Operation(summary = "거래 조회", description = "특정 거래를 조회합니다.")
     @GetMapping("/{transactionId}")
-    public ResponseDto<TransactionDto> getTransaction(@PathVariable Long transactionId) {
+    public ResponseDto<TransactionDto> getTransaction(@AuthUser Member member,
+                                                      @PathVariable Long transactionId) {
         return ResponseDto.onSuccess(
-                TransactionConverter.toTransactionDto(transactionQueryService.getTransaction(transactionId)));
+                TransactionConverter.toTransactionDto(transactionQueryService.getTransaction(member, transactionId)));
     }
 
     @Operation(summary = "특정 날짜의 거래 조회", description = "주어진 날짜에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/date/{date}")
-    public ResponseDto<TransactionListDto> getTransactionsByDate(
-            @PathVariable @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
+    public ResponseDto<TransactionListDto> getTransactionsByDate(@AuthUser Member member,
+                                                                 @PathVariable @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(23, 59, 59);
         return ResponseDto.onSuccess(
                 TransactionConverter.toTransactionListDto(
-                        transactionQueryService.getTransactionsBetweenDates(startOfDay, endOfDay)));
+                        transactionQueryService.getTransactionsBetweenDates(member, startOfDay, endOfDay)));
     }
 
     @Operation(summary = "최근 3개의 거래 조회", description = "가장 최근에 이루어진 3개의 거래를 조회합니다.")
     @GetMapping("/recent")
-    public ResponseDto<TransactionListDto> getRecentTransactions() {
+    public ResponseDto<TransactionListDto> getRecentTransactions(@AuthUser Member member) {
         return ResponseDto.onSuccess(
-                TransactionConverter.toTransactionListDto(transactionQueryService.getRecentTransactions()));
+                TransactionConverter.toTransactionListDto(transactionQueryService.getRecentTransactions(member)));
     }
 
     @Operation(summary = "특정 연도와 달의 거래 조회", description = "주어진 연도와 달에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/year/{year}/month/{month}")
     public ResponseDto<TransactionListDto> getTransactionsByYearAndMonth(
+            @AuthUser Member member,
             @PathVariable int year,
             @PathVariable int month) {
         LocalDate startOfMonth = LocalDate.of(year, month, 1);
@@ -81,8 +87,7 @@ public class TransactionController {
 
         return ResponseDto.onSuccess(
                 TransactionConverter.toTransactionListDto(
-                        transactionQueryService.getTransactionsBetweenDates(startDateTime, endDateTime)));
+                        transactionQueryService.getTransactionsBetweenDates(member, startDateTime, endDateTime)));
     }
-
 
 }

--- a/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
@@ -1,5 +1,6 @@
 package com.friends.easybud.transaction.repository;
 
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.domain.Transaction;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,5 +12,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
                                                    LocalDateTime endDateTime);
 
     List<Transaction> findTop3ByMemberIdOrderByDateDesc(Long memberId);
+
+    void deleteAllByMember(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/transaction/service/TransactionCommandService.java
+++ b/src/main/java/com/friends/easybud/transaction/service/TransactionCommandService.java
@@ -1,11 +1,12 @@
 package com.friends.easybud.transaction.service;
 
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.dto.TransactionRequest.TransactionCreateDto;
 
 public interface TransactionCommandService {
 
-    Long createTransaction(TransactionCreateDto request);
+    Long createTransaction(Member member, TransactionCreateDto request);
 
-    Boolean deleteTransaction(Long transactionId);
+    Boolean deleteTransaction(Member member, Long transactionId);
 
 }

--- a/src/main/java/com/friends/easybud/transaction/service/TransactionQueryService.java
+++ b/src/main/java/com/friends/easybud/transaction/service/TransactionQueryService.java
@@ -1,15 +1,16 @@
 package com.friends.easybud.transaction.service;
 
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.domain.Transaction;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TransactionQueryService {
 
-    Transaction getTransaction(Long transactionId);
+    Transaction getTransaction(Member member, Long transactionId);
 
-    List<Transaction> getTransactionsBetweenDates(LocalDateTime startOfDay, LocalDateTime endOfDay);
+    List<Transaction> getTransactionsBetweenDates(Member member, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
-    List<Transaction> getRecentTransactions();
+    List<Transaction> getRecentTransactions(Member member);
 
 }

--- a/src/main/java/com/friends/easybud/transaction/service/TransactionQueryServiceImpl.java
+++ b/src/main/java/com/friends/easybud/transaction/service/TransactionQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.friends.easybud.transaction.service;
 
 import com.friends.easybud.global.exception.GeneralException;
 import com.friends.easybud.global.response.code.ErrorStatus;
+import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.domain.Transaction;
 import com.friends.easybud.transaction.repository.TransactionRepository;
 import java.time.LocalDateTime;
@@ -18,21 +19,20 @@ public class TransactionQueryServiceImpl implements TransactionQueryService {
     private final TransactionRepository transactionRepository;
 
     @Override
-    public Transaction getTransaction(Long transactionId) {
+    public Transaction getTransaction(Member member, Long transactionId) {
         return transactionRepository.findById(transactionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TRANSACTION_NOT_FOUND));
     }
 
     @Override
-    public List<Transaction> getTransactionsBetweenDates(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        Long memberId = 1L;
-        return transactionRepository.findByMemberIdAndDateBetween(memberId, startDateTime, endDateTime);
+    public List<Transaction> getTransactionsBetweenDates(Member member, LocalDateTime startDateTime,
+                                                         LocalDateTime endDateTime) {
+        return transactionRepository.findByMemberIdAndDateBetween(member.getId(), startDateTime, endDateTime);
     }
 
     @Override
-    public List<Transaction> getRecentTransactions() {
-        Long memberId = 1L;
-        return transactionRepository.findTop3ByMemberIdOrderByDateDesc(memberId);
+    public List<Transaction> getRecentTransactions(Member member) {
+        return transactionRepository.findTop3ByMemberIdOrderByDateDesc(member.getId());
     }
 
 }


### PR DESCRIPTION
## 🔎 Description
> 로그아웃 및 회원 탈퇴 API를 구현하고, JWTAuthenticationFilter와 커스텀 어노테이션 @AuthMember 를 구현하여 사용자 인증을 진행하도록 했습니다.
Swagger에도 헤더에 토큰 포함하여 요청할 수 있도록 설정했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/85](https://github.com/Central-MakeUs/Easybud-Server/issues/85)
- [https://github.com/Central-MakeUs/Easybud-Server/issues/66](https://github.com/Central-MakeUs/Easybud-Server/issues/66)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
