### PR TITLE
[Feat/#87] Swagger API Response 작성

### DIFF
--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.friends.easybud.auth.controller;
 
 import com.friends.easybud.auth.dto.IdTokenRequest;
 import com.friends.easybud.auth.dto.RefreshTokenRequest;
+import com.friends.easybud.auth.dto.SocialLoginResponse;
 import com.friends.easybud.auth.service.AuthService;
 import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
@@ -58,8 +59,8 @@ public class AuthController {
     })
     @Operation(summary = "소셜 로그인", description = "소셜로그인을 진행하고 토큰을 발급합니다.")
     @PostMapping("/social-login")
-    public ResponseDto<JwtDto> socialLogin(@RequestParam(name = "provider") SocialProvider provider,
-                                           @RequestBody IdTokenRequest request) {
+    public ResponseDto<SocialLoginResponse> socialLogin(@RequestParam(name = "provider") SocialProvider provider,
+                                                        @RequestBody IdTokenRequest request) {
         return ResponseDto.onSuccess(authService.socialLogin(provider, request));
     }
 

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -11,8 +11,6 @@ import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.SocialProvider;
 import com.friends.easybud.member.service.MemberCommandService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,16 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @RestController
-@ApiResponses({
-        @ApiResponse(responseCode = "2000", description = "성공"),
-        @ApiResponse(responseCode = "4050", description = "유효하지 않은 토큰입니다."),
-        @ApiResponse(responseCode = "4101", description = "만료된 토큰입니다."),
-        @ApiResponse(responseCode = "4102", description = "지원되지 않는 토큰 형식입니다."),
-        @ApiResponse(responseCode = "4103", description = "토큰 클레임이 비어있습니다."),
-        @ApiResponse(responseCode = "4104", description = "헤더에 refresh token이 존재하지 않습니다."),
-        @ApiResponse(responseCode = "4105", description = "인증 정보가 필요합니다."),
-        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
-})
+//@ApiResponses({
+//        @ApiResponse(responseCode = "2000", description = "성공"),
+//        @ApiResponse(responseCode = "4050", description = "유효하지 않은 토큰입니다."),
+//        @ApiResponse(responseCode = "4101", description = "만료된 토큰입니다."),
+//        @ApiResponse(responseCode = "4102", description = "지원되지 않는 토큰 형식입니다."),
+//        @ApiResponse(responseCode = "4103", description = "토큰 클레임이 비어있습니다."),
+//        @ApiResponse(responseCode = "4104", description = "헤더에 refresh token이 존재하지 않습니다."),
+//        @ApiResponse(responseCode = "4105", description = "인증 정보가 필요합니다."),
+//        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
+//})
 @Tag(name = "Auth API", description = "사용자 API")
 public class AuthController {
 

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -3,14 +3,17 @@ package com.friends.easybud.auth.controller;
 import com.friends.easybud.auth.dto.IdTokenRequest;
 import com.friends.easybud.auth.dto.RefreshTokenRequest;
 import com.friends.easybud.auth.service.AuthService;
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.jwt.JwtDto;
 import com.friends.easybud.jwt.JwtProvider;
 import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.SocialProvider;
 import com.friends.easybud.member.service.MemberCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,16 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @RestController
-//@ApiResponses({
-//        @ApiResponse(responseCode = "2000", description = "성공"),
-//        @ApiResponse(responseCode = "4050", description = "유효하지 않은 토큰입니다."),
-//        @ApiResponse(responseCode = "4101", description = "만료된 토큰입니다."),
-//        @ApiResponse(responseCode = "4102", description = "지원되지 않는 토큰 형식입니다."),
-//        @ApiResponse(responseCode = "4103", description = "토큰 클레임이 비어있습니다."),
-//        @ApiResponse(responseCode = "4104", description = "헤더에 refresh token이 존재하지 않습니다."),
-//        @ApiResponse(responseCode = "4105", description = "인증 정보가 필요합니다."),
-//        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
-//})
+@ApiResponse(responseCode = "2000", description = "성공")
 @Tag(name = "Auth API", description = "사용자 API")
 public class AuthController {
 
@@ -40,12 +34,28 @@ public class AuthController {
     private final AuthService authService;
     private final MemberCommandService memberCommandService;
 
+    @ApiErrorCodeExample({
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.REFRESH_TOKEN_NOT_FOUND,
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
     @PatchMapping("/reissue")
     public ResponseDto<JwtDto> reissue(@RequestBody RefreshTokenRequest request) {
         return ResponseDto.onSuccess(jwtProvider.reissueToken(request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.OAUTH_PROVIDER_NOT_FOUND,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "소셜 로그인", description = "소셜로그인을 진행하고 토큰을 발급합니다.")
     @PostMapping("/social-login")
     public ResponseDto<JwtDto> socialLogin(@RequestParam(name = "provider") SocialProvider provider,
@@ -53,12 +63,24 @@ public class AuthController {
         return ResponseDto.onSuccess(authService.socialLogin(provider, request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     @PostMapping("/logout")
     public ResponseDto<Boolean> logout(@RequestBody RefreshTokenRequest request) {
         return ResponseDto.onSuccess(jwtProvider.logout(request.getRefreshToken()));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @PostMapping("/withdrawal")
     public ResponseDto<Boolean> withdrawal(@AuthMember Member member) {

--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -11,6 +11,8 @@ import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.member.domain.SocialProvider;
 import com.friends.easybud.member.service.MemberCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,6 +25,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @RestController
+@ApiResponses({
+        @ApiResponse(responseCode = "2000", description = "성공"),
+        @ApiResponse(responseCode = "4050", description = "유효하지 않은 토큰입니다."),
+        @ApiResponse(responseCode = "4101", description = "만료된 토큰입니다."),
+        @ApiResponse(responseCode = "4102", description = "지원되지 않는 토큰 형식입니다."),
+        @ApiResponse(responseCode = "4103", description = "토큰 클레임이 비어있습니다."),
+        @ApiResponse(responseCode = "4104", description = "헤더에 refresh token이 존재하지 않습니다."),
+        @ApiResponse(responseCode = "4105", description = "인증 정보가 필요합니다."),
+        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
+})
 @Tag(name = "Auth API", description = "사용자 API")
 public class AuthController {
 

--- a/src/main/java/com/friends/easybud/auth/dto/SocialLoginResponse.java
+++ b/src/main/java/com/friends/easybud/auth/dto/SocialLoginResponse.java
@@ -1,0 +1,25 @@
+package com.friends.easybud.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "소셜 로그인 응답 DTO")
+public class SocialLoginResponse {
+
+    private SocialLoginType type;
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/friends/easybud/auth/dto/SocialLoginType.java
+++ b/src/main/java/com/friends/easybud/auth/dto/SocialLoginType.java
@@ -1,0 +1,5 @@
+package com.friends.easybud.auth.dto;
+
+public enum SocialLoginType {
+    REGISTER, LOGIN
+}

--- a/src/main/java/com/friends/easybud/auth/service/AuthService.java
+++ b/src/main/java/com/friends/easybud/auth/service/AuthService.java
@@ -1,11 +1,11 @@
 package com.friends.easybud.auth.service;
 
 import com.friends.easybud.auth.dto.IdTokenRequest;
-import com.friends.easybud.jwt.JwtDto;
+import com.friends.easybud.auth.dto.SocialLoginResponse;
 import com.friends.easybud.member.domain.SocialProvider;
 
 public interface AuthService {
 
-    JwtDto socialLogin(SocialProvider provider, IdTokenRequest request);
+    SocialLoginResponse socialLogin(SocialProvider provider, IdTokenRequest request);
 
 }

--- a/src/main/java/com/friends/easybud/card/controller/CardController.java
+++ b/src/main/java/com/friends/easybud/card/controller/CardController.java
@@ -7,12 +7,12 @@ import com.friends.easybud.card.dto.CardResponse.CardDto;
 import com.friends.easybud.card.dto.CardResponse.CardListDto;
 import com.friends.easybud.card.service.CardCommandService;
 import com.friends.easybud.card.service.CardQueryService;
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,30 +27,55 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/cards")
 @RestController
-@ApiResponses({
-        @ApiResponse(responseCode = "2000", description = "성공"),
-        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
-        @ApiResponse(responseCode = "4201", description = "접근 권한이 없는 카드입니다."),
-        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
-})
 @Tag(name = "Card API", description = "카드 API")
 public class CardController {
 
     private final CardCommandService cardCommandService;
     private final CardQueryService cardQueryService;
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "카드 생성", description = "새로운 카드를 생성합니다.")
     @PostMapping
     public ResponseDto<Long> createCard(@AuthMember Member member, @RequestBody CardCreateDto request) {
         return ResponseDto.onSuccess(cardCommandService.createCard(member, request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.CARD_NOT_FOUND,
+            ErrorStatus.UNAUTHORIZED_CARD_ACCESS,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "카드 삭제", description = "기존의 카드를 삭제합니다.")
     @DeleteMapping("/{cardId}")
     public ResponseDto<Boolean> deleteCard(@AuthMember Member member, @PathVariable Long cardId) {
         return ResponseDto.onSuccess(cardCommandService.deleteCard(member, cardId));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.CARD_NOT_FOUND,
+            ErrorStatus.UNAUTHORIZED_CARD_ACCESS,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "카드 수정", description = "기존의 카드를 수정합니다.")
     @PutMapping("/{cardId}")
     public ResponseDto<Long> updateCard(@AuthMember Member member, @PathVariable Long cardId,
@@ -58,12 +83,31 @@ public class CardController {
         return ResponseDto.onSuccess(cardCommandService.updateCard(member, cardId, request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.CARD_NOT_FOUND,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "카드 조회", description = "특정 카드를 조회합니다.")
     @GetMapping("/{cardId}")
     public ResponseDto<CardDto> getCard(@AuthMember Member member, @PathVariable Long cardId) {
         return ResponseDto.onSuccess(CardConverter.toCardDto(cardQueryService.getCard(member, cardId)));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "카드 목록 조회", description = "특정 회원의 카드 목록을 조회합니다.")
     @GetMapping
     public ResponseDto<CardListDto> getCards(@AuthMember Member member) {

--- a/src/main/java/com/friends/easybud/card/controller/CardController.java
+++ b/src/main/java/com/friends/easybud/card/controller/CardController.java
@@ -13,6 +13,7 @@ import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/cards")
 @RestController
+@ApiResponse(responseCode = "2000", description = "성공")
 @Tag(name = "Card API", description = "카드 API")
 public class CardController {
 

--- a/src/main/java/com/friends/easybud/card/controller/CardController.java
+++ b/src/main/java/com/friends/easybud/card/controller/CardController.java
@@ -11,6 +11,8 @@ import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/cards")
 @RestController
+@ApiResponses({
+        @ApiResponse(responseCode = "2000", description = "성공"),
+        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
+        @ApiResponse(responseCode = "4201", description = "접근 권한이 없는 카드입니다."),
+        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
+})
 @Tag(name = "Card API", description = "카드 API")
 public class CardController {
 

--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -11,6 +11,8 @@ import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,6 +26,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
 @RestController
+@ApiResponses({
+        @ApiResponse(responseCode = "2000", description = "성공"),
+        @ApiResponse(responseCode = "4150", description = "존재하지 않는 계정 대분류입니다."),
+        @ApiResponse(responseCode = "4151", description = "존재하지 않는 계정 중분류입니다."),
+        @ApiResponse(responseCode = "4152", description = "존재하지 않는 계정 소분류입니다."),
+        @ApiResponse(responseCode = "4153", description = "기본값은 삭제할 수 없습니다."),
+        @ApiResponse(responseCode = "4154", description = "이미 존재하는 계정 소분류입니다."),
+        @ApiResponse(responseCode = "4155", description = "존재하지 않는 카드입니다."),
+        @ApiResponse(responseCode = "5000", description = "접근 권한이 없는 소분류입니다.")
+})
 @Tag(name = "Category API", description = "계정 카테고리 API")
 public class CategoryController {
 

--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -14,7 +14,6 @@ import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,16 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
 @RestController
-@ApiResponses({
-        @ApiResponse(responseCode = "2000", description = "성공"),
-        @ApiResponse(responseCode = "4150", description = "존재하지 않는 계정 대분류입니다."),
-        @ApiResponse(responseCode = "4151", description = "존재하지 않는 계정 중분류입니다."),
-        @ApiResponse(responseCode = "4152", description = "존재하지 않는 계정 소분류입니다."),
-        @ApiResponse(responseCode = "4153", description = "기본값은 삭제할 수 없습니다."),
-        @ApiResponse(responseCode = "4154", description = "이미 존재하는 계정 소분류입니다."),
-        @ApiResponse(responseCode = "4155", description = "존재하지 않는 카드입니다."),
-        @ApiResponse(responseCode = "5000", description = "접근 권한이 없는 소분류입니다.")
-})
+@ApiResponse(responseCode = "2000", description = "성공")
 @Tag(name = "Category API", description = "계정 카테고리 API")
 public class CategoryController {
 

--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -6,8 +6,10 @@ import com.friends.easybud.category.converter.CategoryConverter;
 import com.friends.easybud.category.dto.CategoryRequest.TertiaryCategoryCreateDto;
 import com.friends.easybud.category.service.CategoryCommandService;
 import com.friends.easybud.category.service.CategoryQueryService;
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,6 +44,17 @@ public class CategoryController {
     private final CategoryCommandService categoryCommandService;
     private final CategoryQueryService categoryQueryService;
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.SECONDARY_CATEGORY_NOT_FOUND,
+            ErrorStatus.TERTIARY_CATEGORY_ALREADY_EXISTS,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "계정 소분류 생성", description = "새로운 소분류를 생성합니다.")
     @PostMapping("/tertiary")
     public ResponseDto<Long> createTertiaryCategory(@AuthMember Member member,
@@ -49,6 +62,18 @@ public class CategoryController {
         return ResponseDto.onSuccess(categoryCommandService.createTertiaryCategory(member, request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.TERTIARY_CATEGORY_NOT_FOUND,
+            ErrorStatus.CANNOT_DELETE_DEFAULT_CATEGORY,
+            ErrorStatus.UNAUTHORIZED_TERTIARY_CATEGORY_ACCESS,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "계정 소분류 삭제", description = "기존의 소분류를 삭제합니다.")
     @Parameter(name = "tertiaryCategoryId", description = "삭제할 소분류의 ID")
     @DeleteMapping("/tertiary/{tertiaryCategoryId}")
@@ -57,6 +82,15 @@ public class CategoryController {
         return ResponseDto.onSuccess(categoryCommandService.deleteTertiaryCategory(member, tertiaryCategoryId));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "계정 카테고리 목록 조회", description = "로그인 된 회원의 계정 카테고리 목록을 조회합니다.")
     @GetMapping
     public ResponseDto<AccountCategoryListDto> getAccountCategories(@AuthMember Member member) {

--- a/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
+++ b/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
@@ -13,6 +13,8 @@ import com.friends.easybud.global.response.ResponseDto;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,6 +29,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/financials")
 @RestController
+@ApiResponses({
+        @ApiResponse(responseCode = "2000", description = "성공"),
+        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
+})
 @Tag(name = "Financial API", description = "장부 API")
 public class FinancialController {
 

--- a/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
+++ b/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
@@ -16,7 +16,6 @@ import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,10 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/financials")
 @RestController
-@ApiResponses({
-        @ApiResponse(responseCode = "2000", description = "성공"),
-        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
-})
+@ApiResponse(responseCode = "2000", description = "성공")
 @Tag(name = "Financial API", description = "장부 API")
 public class FinancialController {
 

--- a/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
+++ b/src/main/java/com/friends/easybud/financial/controller/FinancialController.java
@@ -8,8 +8,10 @@ import com.friends.easybud.financial.converter.FinancialConverter;
 import com.friends.easybud.financial.dto.FinancialResponse.IncomeStatementSummaryDto;
 import com.friends.easybud.financial.dto.FinancialResponse.ProfitLossListDto;
 import com.friends.easybud.financial.service.FinancialService;
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,18 +40,45 @@ public class FinancialController {
 
     private final FinancialService financialService;
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "가용자금 조회", description = "사용자의 가용자금을 조회합니다.")
     @GetMapping("/available-funds")
     public ResponseDto<AvailableFundsDto> getAvailableFunds(@AuthMember Member member) {
         return ResponseDto.onSuccess(financialService.getAvailableFunds(member));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "재무 상태 조회", description = "사용자의 재무 상태를 조회합니다.")
     @GetMapping("/financial-statement")
     public ResponseDto<FinancialStatementDto> getFinancialStatement(@AuthMember Member member) {
         return ResponseDto.onSuccess(financialService.getFinancialStatement(member));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "손익현황 조회", description = "사용자의 손익현황을 조회합니다.")
     @Parameter(name = "startDate", example = "2024-02-01")
     @Parameter(name = "endDate", example = "2024-02-02")
@@ -62,6 +91,15 @@ public class FinancialController {
         return ResponseDto.onSuccess(financialService.getIncomeStatement(member, startOfDay, endOfDay));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "월간 손익현황 요약 조회", description = "특정 연도와 월에 대한 손익현황을 조회합니다.")
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")
@@ -77,6 +115,15 @@ public class FinancialController {
         return ResponseDto.onSuccess(financialService.getIncomeStatementSummary(member, startOfMonth, endOfMonth));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "월간 일별 손익현황 요약 조회", description = "특정 연도와 월에 대해 해당 월의 모든 일자별 손익현황을 조회합니다.")
     @Parameter(name = "year", example = "2024")
     @Parameter(name = "month", example = "2")

--- a/src/main/java/com/friends/easybud/global/annotation/ApiErrorCodeExample.java
+++ b/src/main/java/com/friends/easybud/global/annotation/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package com.friends.easybud.global.annotation;
+
+import com.friends.easybud.global.response.code.ErrorStatus;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorStatus[] value();
+
+}

--- a/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
+++ b/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
@@ -1,13 +1,31 @@
 package com.friends.easybud.global.config;
 
+import static java.util.stream.Collectors.groupingBy;
+
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
+import com.friends.easybud.global.response.ExampleHolder;
+import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
+import com.friends.easybud.global.response.code.Reason;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
 
 @Configuration
 public class SwaggerConfig {
@@ -19,8 +37,10 @@ public class SwaggerConfig {
                 .description("Easybud의 API 명세서입니다.");
 
         String jwtSchemeName = "JWT";
+
         // API 요청헤더에 인증정보 포함
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
         // SecuritySchemes 등록
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
@@ -37,4 +57,64 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .addServersItem(server);
     }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExample apiErrorCodeExample =
+                    handlerMethod.getMethodAnnotation(ApiErrorCodeExample.class);
+            if (apiErrorCodeExample != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExample.value());
+            }
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(
+            Operation operation, ErrorStatus[] errorStatuses) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                Arrays.stream(errorStatuses)
+                        .map(
+                                errorStatus -> {
+                                    Reason errorReason = errorStatus.getReason();
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(
+                                                            errorReason.getMessage(),
+                                                            errorReason))
+                                            .code(errorReason.getCode())
+                                            .name(errorReason.getCode().toString())
+                                            .build();
+                                })
+                        .collect(groupingBy(ExampleHolder::getCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(String value, Reason errorReason) {
+        ResponseDto<Object> responseDto = ResponseDto.onFailure(errorReason.getCode(), value, null);
+        Example example = new Example();
+        example.description(value);
+        example.setValue(responseDto);
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(), exampleHolder.getHolder()));
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
+    }
+
 }

--- a/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
+++ b/src/main/java/com/friends/easybud/global/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package com.friends.easybud.global.config;
 
 import static java.util.stream.Collectors.groupingBy;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.response.ExampleHolder;
 import com.friends.easybud.global.response.ResponseDto;
@@ -94,10 +96,18 @@ public class SwaggerConfig {
     }
 
     private Example getSwaggerExample(String value, Reason errorReason) {
-        ResponseDto<Object> responseDto = ResponseDto.onFailure(errorReason.getCode(), value, null);
+        ResponseDto<Object> responseDto = new ResponseDto<>(false, errorReason.getCode(), value, null);
         Example example = new Example();
         example.description(value);
-        example.setValue(responseDto);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String jsonResponseDto = objectMapper.writeValueAsString(responseDto);
+            example.setValue(jsonResponseDto);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        
         return example;
     }
 

--- a/src/main/java/com/friends/easybud/global/response/ExampleHolder.java
+++ b/src/main/java/com/friends/easybud/global/response/ExampleHolder.java
@@ -1,0 +1,15 @@
+package com.friends.easybud.global.response;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+
+}

--- a/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseCode {
 
     // 서버 오류
-    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
+    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 쑤에게 문의 바랍니다."),
     _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
     _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
     _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다."),

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -10,6 +10,8 @@ import com.friends.easybud.transaction.dto.TransactionResponse.TransactionListDt
 import com.friends.easybud.transaction.service.TransactionCommandService;
 import com.friends.easybud.transaction.service.TransactionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,6 +29,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/transactions")
 @RestController
+@ApiResponses({
+        @ApiResponse(responseCode = "2000", description = "성공"),
+        @ApiResponse(responseCode = "4152", description = "존재하지 않는 계정 소분류입니다."),
+        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
+        @ApiResponse(responseCode = "4250", description = "존재하지 않는 거래입니다."),
+        @ApiResponse(responseCode = "4251", description = "접근 권한이 없는 거래입니다."),
+        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
+        @ApiResponse(responseCode = "4300", description = "존재하지 않는 계정입니다."),
+        @ApiResponse(responseCode = "4301", description = "cardId 또는 tertiaryCategoryId 중 하나만 있어야 합니다."),
+        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
+})
 @Tag(name = "Transaction API", description = "거래 API")
 public class TransactionController {
 

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -12,6 +12,7 @@ import com.friends.easybud.transaction.dto.TransactionResponse.TransactionListDt
 import com.friends.easybud.transaction.service.TransactionCommandService;
 import com.friends.easybud.transaction.service.TransactionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/transactions")
 @RestController
+@ApiResponse(responseCode = "2000", description = "성공")
 @Tag(name = "Transaction API", description = "거래 API")
 public class TransactionController {
 

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -1,7 +1,9 @@
 package com.friends.easybud.transaction.controller;
 
+import com.friends.easybud.global.annotation.ApiErrorCodeExample;
 import com.friends.easybud.global.annotation.AuthMember;
 import com.friends.easybud.global.response.ResponseDto;
+import com.friends.easybud.global.response.code.ErrorStatus;
 import com.friends.easybud.member.domain.Member;
 import com.friends.easybud.transaction.converter.TransactionConverter;
 import com.friends.easybud.transaction.dto.TransactionRequest.TransactionCreateDto;
@@ -10,8 +12,6 @@ import com.friends.easybud.transaction.dto.TransactionResponse.TransactionListDt
 import com.friends.easybud.transaction.service.TransactionCommandService;
 import com.friends.easybud.transaction.service.TransactionQueryService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,23 +29,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/transactions")
 @RestController
-@ApiResponses({
-        @ApiResponse(responseCode = "2000", description = "성공"),
-        @ApiResponse(responseCode = "4152", description = "존재하지 않는 계정 소분류입니다."),
-        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
-        @ApiResponse(responseCode = "4250", description = "존재하지 않는 거래입니다."),
-        @ApiResponse(responseCode = "4251", description = "접근 권한이 없는 거래입니다."),
-        @ApiResponse(responseCode = "4200", description = "존재하지 않는 카드입니다."),
-        @ApiResponse(responseCode = "4300", description = "존재하지 않는 계정입니다."),
-        @ApiResponse(responseCode = "4301", description = "cardId 또는 tertiaryCategoryId 중 하나만 있어야 합니다."),
-        @ApiResponse(responseCode = "5000", description = "서버 에러, 쑤에게 문의 바랍니다.")
-})
 @Tag(name = "Transaction API", description = "거래 API")
 public class TransactionController {
 
     private final TransactionCommandService transactionCommandService;
     private final TransactionQueryService transactionQueryService;
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.CARD_NOT_FOUND,
+            ErrorStatus.TERTIARY_CATEGORY_NOT_FOUND,
+            ErrorStatus.ACCOUNT_CREATION_RULE_VIOLATION,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "거래 생성", description = "새로운 거래를 생성합니다.")
     @PostMapping
     public ResponseDto<Long> createTransaction(@AuthMember Member member,
@@ -53,6 +54,15 @@ public class TransactionController {
         return ResponseDto.onSuccess(transactionCommandService.createTransaction(member, request));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "거래 삭제", description = "기존의 거래를 삭제합니다.")
     @DeleteMapping("/{transactionId}")
     public ResponseDto<Boolean> deleteTransaction(@AuthMember Member member,
@@ -60,6 +70,18 @@ public class TransactionController {
         return ResponseDto.onSuccess(transactionCommandService.deleteTransaction(member, transactionId));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus.TRANSACTION_NOT_FOUND,
+            ErrorStatus.UNAUTHORIZED_TRANSACTION_ACCESS,
+            ErrorStatus.TRANSACTION_NOT_FOUND,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "거래 조회", description = "특정 거래를 조회합니다.")
     @GetMapping("/{transactionId}")
     public ResponseDto<TransactionDto> getTransaction(@AuthMember Member member,
@@ -68,6 +90,15 @@ public class TransactionController {
                 TransactionConverter.toTransactionDto(transactionQueryService.getTransaction(member, transactionId)));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "특정 날짜의 거래 조회", description = "주어진 날짜에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/date/{date}")
     public ResponseDto<TransactionListDto> getTransactionsByDate(@AuthMember Member member,
@@ -79,6 +110,15 @@ public class TransactionController {
                         transactionQueryService.getTransactionsBetweenDates(member, startOfDay, endOfDay)));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "최근 3개의 거래 조회", description = "가장 최근에 이루어진 3개의 거래를 조회합니다.")
     @GetMapping("/recent")
     public ResponseDto<TransactionListDto> getRecentTransactions(@AuthMember Member member) {
@@ -86,6 +126,15 @@ public class TransactionController {
                 TransactionConverter.toTransactionListDto(transactionQueryService.getRecentTransactions(member)));
     }
 
+    @ApiErrorCodeExample({
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.TOKEN_INVALID,
+            ErrorStatus.TOKEN_EXPIRED,
+            ErrorStatus.TOKEN_UNSUPPORTED,
+            ErrorStatus.TOKEN_CLAIMS_EMPTY,
+            ErrorStatus.AUTHENTICATION_REQUIRED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @Operation(summary = "특정 연도와 달의 거래 조회", description = "주어진 연도와 달에 해당하는 모든 거래 목록을 조회합니다.")
     @GetMapping("/year/{year}/month/{month}")
     public ResponseDto<TransactionListDto> getTransactionsByYearAndMonth(

--- a/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
+++ b/src/main/java/com/friends/easybud/transaction/controller/TransactionController.java
@@ -49,7 +49,7 @@ public class TransactionController {
             ErrorStatus.ACCOUNT_CREATION_RULE_VIOLATION,
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @Operation(summary = "거래 생성", description = "새로운 거래를 생성합니다.")
+    @Operation(summary = "거래 생성", description = "새로운 거래를 생성합니다. 카드 ID와 소분류 ID 중 하나만 입력해 주세요.")
     @PostMapping
     public ResponseDto<Long> createTransaction(@AuthMember Member member,
                                                @RequestBody TransactionCreateDto request) {


### PR DESCRIPTION
## 🔎 Description
> 커스텀 어노테이션 @ApiErrorCodeExample을 생성한 뒤, Swagger 문서에 API 응답 코드 예시를 작성했습니다. 
추가적으로 소셜 로그인 응답 객체에 로그인, 회원가입 여부 필드를 넣었습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/87](https://github.com/Central-MakeUs/Easybud-Server/issues/87)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
