### PR TITLE
[Feat/#90] 회원 탈퇴 API delete 메서드로 변경

### DIFF
--- a/src/main/java/com/friends/easybud/auth/controller/AuthController.java
+++ b/src/main/java/com/friends/easybud/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,7 +45,7 @@ public class AuthController {
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
     @Operation(summary = "토큰 재발급", description = "Refresh Token, Access Token을 재발급합니다.")
-    @PatchMapping("/reissue")
+    @PostMapping("/reissue")
     public ResponseDto<JwtDto> reissue(@RequestBody RefreshTokenRequest request) {
         return ResponseDto.onSuccess(jwtProvider.reissueToken(request));
     }
@@ -83,7 +83,7 @@ public class AuthController {
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
-    @PostMapping("/withdrawal")
+    @DeleteMapping("/withdrawal")
     public ResponseDto<Boolean> withdrawal(@AuthMember Member member) {
         return ResponseDto.onSuccess(memberCommandService.withdrawal(member));
     }


### PR DESCRIPTION
## 🔎 Description
> 기존에 post로 설정되어 있던 회원 탈퇴 API를 delete로 변경합니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/90](https://github.com/Central-MakeUs/Easybud-Server/issues/90)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
