### PR TITLE
[Feat/#94] 계정 카테고리 목록 조회 API 로직 수정

### DIFF
--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -85,7 +85,10 @@ public class CategoryController {
     @GetMapping
     public ResponseDto<AccountCategoryListDto> getAccountCategories(@AuthMember Member member) {
         return ResponseDto.onSuccess(
-                CategoryConverter.toAccountCategoryListDto(categoryQueryService.getTertiaryCategories(member)));
+                CategoryConverter.toAccountCategoryListDto(
+                        categoryQueryService.getSecondaryCategories(),
+                        categoryQueryService.getTertiaryCategories(member)
+                ));
     }
 
 }

--- a/src/main/java/com/friends/easybud/category/converter/CategoryConverter.java
+++ b/src/main/java/com/friends/easybud/category/converter/CategoryConverter.java
@@ -1,33 +1,51 @@
 package com.friends.easybud.category.converter;
 
+import com.friends.easybud.category.domain.SecondaryCategory;
 import com.friends.easybud.category.domain.TertiaryCategory;
 import com.friends.easybud.category.dto.CategoryResponse.AccountCategoryDto;
 import com.friends.easybud.category.dto.CategoryResponse.AccountCategoryListDto;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class CategoryConverter {
 
-    public static AccountCategoryDto toAccountCategoryDto(TertiaryCategory tertiaryCategory) {
-        return AccountCategoryDto.builder()
-                .primaryCategoryId(tertiaryCategory.getSecondaryCategory().getPrimaryCategory().getId())
-                .primaryCategoryContent(tertiaryCategory.getSecondaryCategory().getPrimaryCategory().getContent())
-                .secondaryCategoryId(tertiaryCategory.getSecondaryCategory().getId())
-                .secondaryCategoryContent(tertiaryCategory.getSecondaryCategory().getContent())
-                .tertiaryCategoryId(tertiaryCategory.getId())
-                .tertiaryCategoryContent(tertiaryCategory.getContent())
-                .isDefault(tertiaryCategory.getIsDefault())
-                .build();
+    public static AccountCategoryDto toAccountCategoryDto(SecondaryCategory secondaryCategory,
+                                                          TertiaryCategory tertiaryCategory) {
+        AccountCategoryDto.AccountCategoryDtoBuilder builder = AccountCategoryDto.builder()
+                .primaryCategoryId(secondaryCategory.getPrimaryCategory().getId())
+                .primaryCategoryContent(secondaryCategory.getPrimaryCategory().getContent())
+                .secondaryCategoryId(secondaryCategory.getId())
+                .secondaryCategoryContent(secondaryCategory.getContent());
+
+        if (tertiaryCategory != null) {
+            builder.tertiaryCategoryId(tertiaryCategory.getId())
+                    .tertiaryCategoryContent(tertiaryCategory.getContent())
+                    .isDefault(tertiaryCategory.getIsDefault());
+        }
+
+        return builder.build();
     }
 
-    public static AccountCategoryListDto toAccountCategoryListDto(List<TertiaryCategory> tertiaryCategories) {
-        List<AccountCategoryDto> accountCategoryDtos = tertiaryCategories.stream()
-                .map(CategoryConverter::toAccountCategoryDto)
-                .collect(Collectors.toList());
+    public static AccountCategoryListDto toAccountCategoryListDto(List<SecondaryCategory> secondaryCategories,
+                                                                  List<TertiaryCategory> tertiaryCategories) {
+        List<AccountCategoryDto> accountCategoryDtos = new ArrayList<>();
+
+        for (SecondaryCategory secondaryCategory : secondaryCategories) {
+            List<TertiaryCategory> relatedTertiaryCategories = tertiaryCategories.stream()
+                    .filter(tc -> tc.getSecondaryCategory().equals(secondaryCategory))
+                    .collect(Collectors.toList());
+
+            if (relatedTertiaryCategories.isEmpty()) {
+                accountCategoryDtos.add(toAccountCategoryDto(secondaryCategory, null));
+            } else {
+                relatedTertiaryCategories.forEach(tertiaryCategory ->
+                        accountCategoryDtos.add(toAccountCategoryDto(secondaryCategory, tertiaryCategory)));
+            }
+        }
 
         return AccountCategoryListDto.builder()
                 .accountCategories(accountCategoryDtos)
                 .build();
     }
-
 }

--- a/src/main/java/com/friends/easybud/category/service/CategoryQueryService.java
+++ b/src/main/java/com/friends/easybud/category/service/CategoryQueryService.java
@@ -1,5 +1,6 @@
 package com.friends.easybud.category.service;
 
+import com.friends.easybud.category.domain.SecondaryCategory;
 import com.friends.easybud.category.domain.TertiaryCategory;
 import com.friends.easybud.member.domain.Member;
 import java.util.List;
@@ -7,5 +8,7 @@ import java.util.List;
 public interface CategoryQueryService {
 
     List<TertiaryCategory> getTertiaryCategories(Member member);
+
+    List<SecondaryCategory> getSecondaryCategories();
 
 }

--- a/src/main/java/com/friends/easybud/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/friends/easybud/category/service/CategoryQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.friends.easybud.category.service;
 
+import com.friends.easybud.category.domain.SecondaryCategory;
 import com.friends.easybud.category.domain.TertiaryCategory;
+import com.friends.easybud.category.repository.SecondaryCategoryRepository;
 import com.friends.easybud.category.repository.TertiaryCategoryRepository;
 import com.friends.easybud.member.domain.Member;
 import java.util.List;
@@ -13,11 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CategoryQueryServiceImpl implements CategoryQueryService {
 
+    private final SecondaryCategoryRepository secondaryCategoryRepository;
     private final TertiaryCategoryRepository tertiaryCategoryRepository;
 
     @Override
     public List<TertiaryCategory> getTertiaryCategories(Member member) {
         return tertiaryCategoryRepository.findByMemberIdOrIsDefaultTrue(member.getId());
+    }
+
+    @Override
+    public List<SecondaryCategory> getSecondaryCategories() {
+        return secondaryCategoryRepository.findAll();
     }
 
 }

--- a/src/main/java/com/friends/easybud/transaction/service/TransactionCommandServiceImpl.java
+++ b/src/main/java/com/friends/easybud/transaction/service/TransactionCommandServiceImpl.java
@@ -55,10 +55,12 @@ public class TransactionCommandServiceImpl implements TransactionCommandService 
             Card card = cardRepository.findById(accountDto.getCardId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CARD_NOT_FOUND));
             account = buildAccount(accountDto, card, null);
-        } else {
+        } else if (accountDto.getTertiaryCategoryId() != null) {
             TertiaryCategory tertiaryCategory = tertiaryCategoryRepository.findById(accountDto.getTertiaryCategoryId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.TERTIARY_CATEGORY_NOT_FOUND));
             account = buildAccount(accountDto, null, tertiaryCategory);
+        } else {
+            account = buildAccount(accountDto, null, null);
         }
 
         account.addTransaction(transaction);


### PR DESCRIPTION
## 🔎 Description
> 계정 카테고리 목록 조회 API를 중분류를 기준으로 조회하도록 수정했습니다. 
추가로 Transaction 생성 부분에서 tertiaryCategoryId와 cardId 둘 다 null인 경우에도 정상적으로 계정이 저장되도록 로직을 수정했습니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/94](https://github.com/Central-MakeUs/Easybud-Server/issues/94)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
