### PR TITLE
[Feat/#98] 중복 거래 생성 방지 기능 구현

### DIFF
--- a/src/main/java/com/friends/easybud/category/dto/CategoryRequest.java
+++ b/src/main/java/com/friends/easybud/category/dto/CategoryRequest.java
@@ -22,7 +22,7 @@ public class CategoryRequest {
         @Schema(description = "중분류 ID", example = "1")
         private Long secondaryCategoryId;
 
-        @Schema(description = "소분류 내용", example = "외화")
+        @Schema(description = "소분류 이름", example = "외화")
         private String tertiaryCategoryContent;
 
     }

--- a/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/friends/easybud/global/response/code/ErrorStatus.java
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseCode {
     // Transaction: 4250 ~ 4299
     TRANSACTION_NOT_FOUND(NOT_FOUND, 4250, "존재하지 않는 거래입니다."),
     UNAUTHORIZED_TRANSACTION_ACCESS(BAD_REQUEST, 4251, "접근 권한이 없는 거래입니다."),
+    DUPLICATE_TRANSACTION_CREATION(BAD_REQUEST, 4252, "중복된 거래 생성 요청입니다. 잠시 후 다시 시도해주세요."),
 
     // Account: 4300 ~ 4349
     ACCOUNT_NOT_FOUND(NOT_FOUND, 4300, "존재하지 않는 계정입니다."),

--- a/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/friends/easybud/transaction/repository/TransactionRepository.java
@@ -5,6 +5,8 @@ import com.friends.easybud.transaction.domain.Transaction;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
@@ -14,5 +16,8 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
     List<Transaction> findTop3ByMemberIdOrderByDateDesc(Long memberId);
 
     void deleteAllByMember(Member member);
+
+    @Query("SELECT t FROM Transaction t WHERE t.member = :member ORDER BY t.createdDate DESC")
+    List<Transaction> findLastTransactionByMember(@Param("member") Member member);
 
 }


### PR DESCRIPTION
## 🔎 Description
> 중복 거래 생성 방지를 기능을 구현했습니다. 거래 생성 간격은 30초로 설정했습니다.

## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/98](https://github.com/Central-MakeUs/Easybud-Server/issues/98)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
