### PR TITLE
[Feat/#108] 카테고리 조회 시 소분류, 카드 정보 통합

### DIFF
--- a/src/main/java/com/friends/easybud/category/controller/CategoryController.java
+++ b/src/main/java/com/friends/easybud/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.friends.easybud.category.controller;
 
 import static com.friends.easybud.category.dto.CategoryResponse.AccountCategoryListDto;
 
+import com.friends.easybud.card.service.CardQueryService;
 import com.friends.easybud.category.converter.CategoryConverter;
 import com.friends.easybud.category.dto.CategoryRequest.TertiaryCategoryCreateDto;
 import com.friends.easybud.category.dto.CategoryResponse.TertiaryCategorySummaryDto;
@@ -34,6 +35,7 @@ public class CategoryController {
 
     private final CategoryCommandService categoryCommandService;
     private final CategoryQueryService categoryQueryService;
+    private final CardQueryService cardQueryService;
 
     @ApiErrorCodeExample({
             ErrorStatus.MEMBER_NOT_FOUND,
@@ -89,7 +91,8 @@ public class CategoryController {
         return ResponseDto.onSuccess(
                 CategoryConverter.toAccountCategoryListDto(
                         categoryQueryService.getSecondaryCategories(),
-                        categoryQueryService.getTertiaryCategories(member)
+                        categoryQueryService.getTertiaryCategories(member),
+                        cardQueryService.getCards(member)
                 ));
     }
 

--- a/src/main/java/com/friends/easybud/category/converter/CategoryConverter.java
+++ b/src/main/java/com/friends/easybud/category/converter/CategoryConverter.java
@@ -1,5 +1,6 @@
 package com.friends.easybud.category.converter;
 
+import com.friends.easybud.card.domain.Card;
 import com.friends.easybud.category.domain.SecondaryCategory;
 import com.friends.easybud.category.domain.TertiaryCategory;
 import com.friends.easybud.category.dto.CategoryResponse.AccountCategoryDto;
@@ -29,19 +30,16 @@ public class CategoryConverter {
     }
 
     public static AccountCategoryListDto toAccountCategoryListDto(List<SecondaryCategory> secondaryCategories,
-                                                                  List<TertiaryCategory> tertiaryCategories) {
+                                                                  List<TertiaryCategory> tertiaryCategories,
+                                                                  List<Card> cards) {
         List<AccountCategoryDto> accountCategoryDtos = new ArrayList<>();
 
         for (SecondaryCategory secondaryCategory : secondaryCategories) {
-            List<TertiaryCategory> relatedTertiaryCategories = tertiaryCategories.stream()
-                    .filter(tc -> tc.getSecondaryCategory().equals(secondaryCategory))
-                    .collect(Collectors.toList());
-
-            if (relatedTertiaryCategories.isEmpty()) {
-                accountCategoryDtos.add(toAccountCategoryDto(secondaryCategory, null));
+            if (secondaryCategory.getId() == 8) {
+                processCardsForCategory(cards, secondaryCategory, accountCategoryDtos);
             } else {
-                relatedTertiaryCategories.forEach(tertiaryCategory ->
-                        accountCategoryDtos.add(toAccountCategoryDto(secondaryCategory, tertiaryCategory)));
+                processTertiaryCategoriesForSecondaryCategory(secondaryCategory, tertiaryCategories,
+                        accountCategoryDtos);
             }
         }
 
@@ -50,11 +48,47 @@ public class CategoryConverter {
                 .build();
     }
 
+    private static void processCardsForCategory(List<Card> cards, SecondaryCategory secondaryCategory,
+                                                List<AccountCategoryDto> accountCategoryDtos) {
+        cards.forEach(card -> accountCategoryDtos.add(createAccountCategoryDtoFromCard(secondaryCategory, card)));
+    }
+
+    private static AccountCategoryDto createAccountCategoryDtoFromCard(SecondaryCategory secondaryCategory, Card card) {
+        return AccountCategoryDto.builder()
+                .primaryCategoryId(secondaryCategory.getPrimaryCategory().getId())
+                .primaryCategoryContent(secondaryCategory.getPrimaryCategory().getContent())
+                .secondaryCategoryId(secondaryCategory.getId())
+                .secondaryCategoryContent(secondaryCategory.getContent())
+                .tertiaryCategoryId(card.getId())
+                .tertiaryCategoryContent(card.getName())
+                .build();
+    }
+
+    private static void processTertiaryCategoriesForSecondaryCategory(SecondaryCategory secondaryCategory,
+                                                                      List<TertiaryCategory> tertiaryCategories,
+                                                                      List<AccountCategoryDto> accountCategoryDtos) {
+        List<TertiaryCategory> relatedTertiaryCategories = filterTertiaryCategoriesForSecondaryCategory(
+                secondaryCategory, tertiaryCategories);
+
+        if (relatedTertiaryCategories.isEmpty()) {
+            accountCategoryDtos.add(toAccountCategoryDto(secondaryCategory, null));
+        } else {
+            relatedTertiaryCategories.forEach(tertiaryCategory -> accountCategoryDtos.add(
+                    toAccountCategoryDto(secondaryCategory, tertiaryCategory)));
+        }
+    }
+
+    private static List<TertiaryCategory> filterTertiaryCategoriesForSecondaryCategory(
+            SecondaryCategory secondaryCategory, List<TertiaryCategory> tertiaryCategories) {
+        return tertiaryCategories.stream()
+                .filter(tc -> tc.getSecondaryCategory().equals(secondaryCategory))
+                .collect(Collectors.toList());
+    }
+
     public static TertiaryCategorySummaryDto toTertiaryCategorySummaryDto(TertiaryCategory tertiaryCategory) {
         return TertiaryCategorySummaryDto.builder()
                 .tertiaryCategoryId(tertiaryCategory.getId())
                 .tertiaryCategoryContent(tertiaryCategory.getContent())
                 .build();
     }
-
 }


### PR DESCRIPTION
## 🔎 Description
> 카테고리 목록을 조회할 때 카드 정보까지 조회되도록 수정합니다.


## 🔗 Related Issue
- [https://github.com/Central-MakeUs/Easybud-Server/issues/108](https://github.com/Central-MakeUs/Easybud-Server/issues/108)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
